### PR TITLE
Albrja/mic 5289/anc component

### DIFF
--- a/src/vivarium_gates_mncnh/components/__init__.py
+++ b/src/vivarium_gates_mncnh/components/__init__.py
@@ -1,3 +1,4 @@
+from vivarium_gates_mncnh.components.antenatal_care import AntenatalCare
 from vivarium_gates_mncnh.components.observers import BirthObserver, ResultsStratifier
 from vivarium_gates_mncnh.components.pregnancy import Pregnancy
 from vivarium_gates_mncnh.plugins.time import EventClock, TimeInterface

--- a/src/vivarium_gates_mncnh/components/antenatal_care.py
+++ b/src/vivarium_gates_mncnh/components/antenatal_care.py
@@ -102,7 +102,7 @@ class ANCState(TransientDecisionTreeState):
 
 class UltrasoundState(TransientDecisionTreeState):
     def __init__(self, ultrasound_type: str) -> None:
-        super().__init__(f"{ultrasound_type}_ultasound")
+        super().__init__(f"{ultrasound_type}_ultrasound")
         self.ultrasound_type = ultrasound_type
 
     @property
@@ -139,7 +139,7 @@ class AntenatalCare(Component):
 
     def __init__(self) -> None:
         super().__init__()
-        self.decision_tree = self.create_anc_machine()
+        self.decision_tree = self.create_anc_decision_tree()
 
     def setup(self, builder: Builder):
         self._sim_step_name = builder.time.simulation_event_name()
@@ -229,7 +229,7 @@ class AntenatalCare(Component):
         identification[lbw_index] = draws < identification_rates
         return identification
 
-    def create_anc_machine(self) -> Machine:
+    def create_anc_decision_tree(self) -> Machine:
         initial_state = DecisionTreeState("initial")
         attended_antental_care = ANCState()
         gets_ultrasound = TransientDecisionTreeState("gets_ultrasound")

--- a/src/vivarium_gates_mncnh/components/antenatal_care.py
+++ b/src/vivarium_gates_mncnh/components/antenatal_care.py
@@ -55,7 +55,6 @@ class TreeMachine(Machine):
 class DecisionTreeState(State):
     def setup(self, builder: Builder) -> None:
         self._sim_step_name = builder.time.simulation_event_name()
-        self.location = get_location(builder)
 
     def add_decision(
         self,
@@ -249,26 +248,28 @@ class AntenatalCare(Component):
         attended_antental_care.add_decision(
             gets_ultrasound,
             lambda index: pd.Series(
-                ANC_RATES.RECEIVED_ULTRASOUND[attended_antental_care.location], index=index
+                ANC_RATES.RECEIVED_ULTRASOUND[self.location], index=index
             ),
         )
         attended_antental_care.add_decision(
             end_state,
             lambda index: pd.Series(
-                1 - ANC_RATES.RECEIVED_ULTRASOUND[attended_antental_care.location],
+                1 - ANC_RATES.RECEIVED_ULTRASOUND[self.location],
                 index=index,
             ),
         )
         gets_ultrasound.add_decision(
             standard_ultasound,
             lambda index: pd.Series(
-                ANC_RATES.ULTRASOUND_TYPE[ULTRASOUND_TYPES.STANDARD], index=index
+                ANC_RATES.ULTRASOUND_TYPE[self.location][ULTRASOUND_TYPES.STANDARD],
+                index=index,
             ),
         )
         gets_ultrasound.add_decision(
             ai_assisted_ultrasound,
             lambda index: pd.Series(
-                ANC_RATES.ULTRASOUND_TYPE[ULTRASOUND_TYPES.AI_ASSISTED], index=index
+                ANC_RATES.ULTRASOUND_TYPE[self.location][ULTRASOUND_TYPES.AI_ASSISTED],
+                index=index,
             ),
         )
         standard_ultasound.add_decision(end_state)

--- a/src/vivarium_gates_mncnh/components/antenatal_care.py
+++ b/src/vivarium_gates_mncnh/components/antenatal_care.py
@@ -1,15 +1,142 @@
+from typing import Callable
+
 import numpy as np
 import pandas as pd
 from vivarium import Component
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
+from vivarium.types import ClockTime
 from vivarium.framework.population import SimulantData
+from vivarium.framework.state_machine import Machine, State, Transient, Transition
 
 from vivarium_gates_mncnh.constants.data_values import (
     ANC_RATES,
     COLUMNS,
     SIMULATION_EVENT_NAMES,
 )
+from vivarium_gates_mncnh.utilities import get_location
+
+
+class DecisionTreeState(State):
+    def setup(self, builder: Builder) -> None:
+        self._sim_step_name = builder.time.simulation_event_name()
+        self.location = get_location(builder)
+
+    def add_decision(
+        self,
+        output_state: State,
+        decision_function: Callable[[pd.Index], pd.Series],
+    ) -> None:
+        def probability_function(index: pd.Index) -> pd.Series:
+            if self._sim_step_name != SIMULATION_EVENT_NAMES.PREGNANCY:
+                return pd.Series(0.0, index=index)
+            return decision_function(index)
+
+        transition = Transition(self, output_state, probability_function)
+        self.add_transition(transition)
+
+
+class TransientDecisionTreeState(DecisionTreeState, Transient):
+    pass
+
+
+class ANCState(TransientDecisionTreeState):
+    def __init__(self) -> None:
+        super().__init__("attended_antental_care")
+
+    @property
+    def columns_required(self) -> list[str]:
+        return [COLUMNS.ATTENDED_CARE_FACILITY]
+
+    def transition_side_effect(self, index: pd.Index, _event_time: ClockTime) -> None:
+        pop = self.population_view.get(index)
+        pop[COLUMNS.ATTENDED_CARE_FACILITY] = True
+        self.population_view.update(pop)
+
+
+class StandardUltrasound(TransientDecisionTreeState):
+    def __init__(self) -> None:
+        super().__init__("standard_ultasound")
+
+    @property
+    def columns_required(self) -> list[str]:
+        return [COLUMNS.ULTRASOUND_TYPE]
+
+    def transition_side_effect(self, index: pd.Index, _event_time: ClockTime) -> None:
+        pop = self.population_view.get(index)
+        pop[COLUMNS.ULTRASOUND_TYPE] = "standard"
+        self.population_view.update(pop)
+
+
+class AIAssistedUltrasound(TransientDecisionTreeState):
+    def __init__(self) -> None:
+        super().__init__("ai_assisted_ultrasound")
+
+    @property
+    def columns_required(self) -> list[str]:
+        return [COLUMNS.ULTRASOUND_TYPE]
+
+    def transition_side_effect(self, index: pd.Index, _event_time: ClockTime) -> None:
+        pop = self.population_view.get(index)
+        pop[COLUMNS.ULTRASOUND_TYPE] = "AI_assisted"
+        self.population_view.update(pop)
+
+
+def ANC() -> Machine:
+    initial_state = DecisionTreeState("initial")
+    attended_antental_care = ANCState()
+    gets_ultrasound = TransientDecisionTreeState("gets_ultrasound")
+    standard_ultasound = StandardUltrasound()
+    ai_assisted_ultrasound = AIAssistedUltrasound()
+    end_state = DecisionTreeState("end")
+
+    # Decisions
+    initial_state.add_decision(
+        attended_antental_care,
+        lambda index: pd.Series(
+            ANC_RATES.ATTENDED_CARE_FACILITY[initial_state.location], index=index
+        ),
+    )
+    initial_state.add_decision(
+        end_state,
+        lambda index: pd.Series(
+            1 - ANC_RATES.ATTENDED_CARE_FACILITY[initial_state.location], index=index
+        ),
+    )
+    attended_antental_care.add_decision(
+        gets_ultrasound,
+        lambda index: pd.Series(
+            ANC_RATES.RECEIVED_ULTRASOUND[attended_antental_care.location], index=index
+        ),
+    )
+    attended_antental_care.add_decision(
+        end_state,
+        lambda index: pd.Series(
+            1 - ANC_RATES.RECEIVED_ULTRASOUND[attended_antental_care.location], index=index
+        ),
+    )
+    gets_ultrasound.add_decision(
+        standard_ultasound,
+        lambda index: pd.Series(ANC_RATES.ULTRASOUND_TYPE["standard"], index=index),
+    )
+    gets_ultrasound.add_decision(
+        ai_assisted_ultrasound,
+        lambda index: pd.Series(1 - ANC_RATES.ULTRASOUND_TYPE["AI_assisted"], index=index),
+    )
+    standard_ultasound.add_decision(end_state, lambda index: pd.Series(1, index=index))
+    ai_assisted_ultrasound.add_decision(end_state, lambda index: pd.Series(1, index=index))
+
+    return Machine(
+        "anc_state",
+        [
+            initial_state,
+            attended_antental_care,
+            gets_ultrasound,
+            standard_ultasound,
+            ai_assisted_ultrasound,
+            end_state,
+        ],
+    )
 
 
 class AntenatalCare(Component):
@@ -17,7 +144,6 @@ class AntenatalCare(Component):
     def columns_created(self):
         return [
             COLUMNS.ATTENDED_CARE_FACILITY,
-            COLUMNS.RECEIVED_ULTRASOUND,
             COLUMNS.ULTRASOUND_TYPE,
             COLUMNS.STATED_GESTATIONAL_AGE,
             COLUMNS.SUCCESSFUL_LBW_IDENTIFICATION,
@@ -31,21 +157,27 @@ class AntenatalCare(Component):
             COLUMNS.SEX_OF_CHILD,
         ]
 
+    @property
+    def sub_components(self) -> list[Component]:
+        return [self.machine]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.machine = ANC()
+
     def setup(self, builder: Builder):
         self._sim_step_name = builder.time.simulation_event_name()
         self.randomness = builder.randomness.get_stream(self.name)
-        self.location = self._get_location(builder)
+        self.location = get_location(builder)
 
     def build_all_lookup_tables(self, builder: Builder) -> None:
         # TODO: I don't think we need this
         pass
 
     def on_initialize_simulants(self, pop_data: SimulantData) -> None:
-        # TODO: is this the best data to initialize these columns with?
         anc_data = pd.DataFrame(
             {
                 COLUMNS.ATTENDED_CARE_FACILITY: False,
-                COLUMNS.RECEIVED_ULTRASOUND: False,
                 COLUMNS.ULTRASOUND_TYPE: "no_ultrasound",
                 COLUMNS.STATED_GESTATIONAL_AGE: np.nan,
                 COLUMNS.SUCCESSFUL_LBW_IDENTIFICATION: np.nan,
@@ -54,70 +186,6 @@ class AntenatalCare(Component):
         )
         self.population_view.update(anc_data)
 
-    def on_time_step(self, event: Event) -> None:
-        """We need to make 3 decisions in this method and record data based on that decision tree.
-        First, we need to decide whether simulants go to a care facility for ANC. Second, we need
-        to decide if the simulants that attend a care facility get an ultrasound. Finally, we need
-        to determine what type of ultrasound a simulant received if they got an ultrasound. We also
-        need to record the stated gestational age and whether the child was successfully identified
-        as low birth weight. Because we are walking through a decision tree, oder of operations is
-        very important.
-        """
-        # TODO: is this necessary?
-        if self._sim_step_name != SIMULATION_EVENT_NAMES.PREGNANCY:
-            pass
-        population = self.population_view.get(event.index)
-
-        # Decide if simulants went to a facility for ANC
-        population[COLUMNS.ATTENDED_CARE_FACILITY] = self.randomness.choice(
-            index=population.index,
-            choices=[True, False],
-            p=[
-                ANC_RATES.ATTENDED_CARE_FACILITY[self.location],
-                (1 - ANC_RATES.ATTENDED_CARE_FACILITY[self.location]),
-            ],
-            additional_key="attended_care_facility",
-        )
-        # Decide if simulants that went to a facility got an ultrasound
-        anc_index = population.index[population[COLUMNS.ATTENDED_CARE_FACILITY] == True]
-        ultrasound_decision = self.randomness.choice(
-            index=anc_index,
-            choices=[True, False],
-            p=[
-                ANC_RATES.RECEIVED_ULTRASOUND[self.location],
-                (1 - ANC_RATES.RECEIVED_ULTRASOUND[self.location]),
-            ],
-            additional_key="received_ultrasound",
-        )
-        population.loc[anc_index, COLUMNS.RECEIVED_ULTRASOUND] = ultrasound_decision
-
-        # Decide what type of ultrasound a simulant received
-        ultrasound_index = population.index[population[COLUMNS.RECEIVED_ULTRASOUND] == True]
-        # TODO: update data
-        ultrasound_type = self.randomness.choice(
-            index=ultrasound_index,
-            choices=["standard", "AI_assisted"],
-            p=[
-                ANC_RATES.ULTRASOUND_TYPE["standard"],
-                ANC_RATES.ULTRASOUND_TYPE["AI_assisted"],
-            ],
-        )
-        population.loc[ultrasound_index, COLUMNS.ULTRASOUND_TYPE] = ultrasound_type
-
-        # Get index groups for each ultrasound type
-        no_ultrasound_index = population.index[
-            population[COLUMNS.ULTRASOUND_TYPE] == "no_ultrasound"
-        ]
-        standard_ultrasound_index = population.index[
-            population[COLUMNS.ULTRASOUND_TYPE] == "standard"
-        ]
-        ai_ultrasound_index = population.index[
-            population[COLUMNS.ULTRASOUND_TYPE] == "AI_assisted"
-        ]
-
-        # Record the stated gestational age
-
-        # Record whether the child was successfully identified as low birth weight
-
-    def _get_location(self, builder: Builder) -> str:
-        return builder.data.load("population.location")
+    def on_time_step_cleanup(self, event: Event) -> None:
+        # TODO: Add columns of stated gestational age and successful lbw identification
+        pass

--- a/src/vivarium_gates_mncnh/components/antenatal_care.py
+++ b/src/vivarium_gates_mncnh/components/antenatal_care.py
@@ -1,0 +1,123 @@
+import numpy as np
+import pandas as pd
+from vivarium import Component
+from vivarium.framework.engine import Builder
+from vivarium.framework.event import Event
+from vivarium.framework.population import SimulantData
+
+from vivarium_gates_mncnh.constants.data_values import (
+    ANC_RATES,
+    COLUMNS,
+    SIMULATION_EVENT_NAMES,
+)
+
+
+class AntenatalCare(Component):
+    @property
+    def columns_created(self):
+        return [
+            COLUMNS.ATTENDED_CARE_FACILITY,
+            COLUMNS.RECEIVED_ULTRASOUND,
+            COLUMNS.ULTRASOUND_TYPE,
+            COLUMNS.STATED_GESTATIONAL_AGE,
+            COLUMNS.SUCCESSFUL_LBW_IDENTIFICATION,
+        ]
+
+    @property
+    def columns_required(self):
+        return [
+            COLUMNS.GESTATIONAL_AGE,
+            COLUMNS.BIRTH_WEIGHT,
+            COLUMNS.SEX_OF_CHILD,
+        ]
+
+    def setup(self, builder: Builder):
+        self._sim_step_name = builder.time.simulation_event_name()
+        self.randomness = builder.randomness.get_stream(self.name)
+        self.location = self._get_location(builder)
+
+    def build_all_lookup_tables(self, builder: Builder) -> None:
+        # TODO: I don't think we need this
+        pass
+
+    def on_initialize_simulants(self, pop_data: SimulantData) -> None:
+        # TODO: is this the best data to initialize these columns with?
+        anc_data = pd.DataFrame(
+            {
+                COLUMNS.ATTENDED_CARE_FACILITY: False,
+                COLUMNS.RECEIVED_ULTRASOUND: False,
+                COLUMNS.ULTRASOUND_TYPE: "no_ultrasound",
+                COLUMNS.STATED_GESTATIONAL_AGE: np.nan,
+                COLUMNS.SUCCESSFUL_LBW_IDENTIFICATION: np.nan,
+            },
+            index=pop_data.index,
+        )
+        self.population_view.update(anc_data)
+
+    def on_time_step(self, event: Event) -> None:
+        """We need to make 3 decisions in this method and record data based on that decision tree.
+        First, we need to decide whether simulants go to a care facility for ANC. Second, we need
+        to decide if the simulants that attend a care facility get an ultrasound. Finally, we need
+        to determine what type of ultrasound a simulant received if they got an ultrasound. We also
+        need to record the stated gestational age and whether the child was successfully identified
+        as low birth weight. Because we are walking through a decision tree, oder of operations is
+        very important.
+        """
+        # TODO: is this necessary?
+        if self._sim_step_name != SIMULATION_EVENT_NAMES.PREGNANCY:
+            pass
+        population = self.population_view.get(event.index)
+
+        # Decide if simulants went to a facility for ANC
+        population[COLUMNS.ATTENDED_CARE_FACILITY] = self.randomness.choice(
+            index=population.index,
+            choices=[True, False],
+            p=[
+                ANC_RATES.ATTENDED_CARE_FACILITY[self.location],
+                (1 - ANC_RATES.ATTENDED_CARE_FACILITY[self.location]),
+            ],
+            additional_key="attended_care_facility",
+        )
+        # Decide if simulants that went to a facility got an ultrasound
+        anc_index = population.index[population[COLUMNS.ATTENDED_CARE_FACILITY] == True]
+        ultrasound_decision = self.randomness.choice(
+            index=anc_index,
+            choices=[True, False],
+            p=[
+                ANC_RATES.RECEIVED_ULTRASOUND[self.location],
+                (1 - ANC_RATES.RECEIVED_ULTRASOUND[self.location]),
+            ],
+            additional_key="received_ultrasound",
+        )
+        population.loc[anc_index, COLUMNS.RECEIVED_ULTRASOUND] = ultrasound_decision
+
+        # Decide what type of ultrasound a simulant received
+        ultrasound_index = population.index[population[COLUMNS.RECEIVED_ULTRASOUND] == True]
+        # TODO: update data
+        ultrasound_type = self.randomness.choice(
+            index=ultrasound_index,
+            choices=["standard", "AI_assisted"],
+            p=[
+                ANC_RATES.ULTRASOUND_TYPE["standard"],
+                ANC_RATES.ULTRASOUND_TYPE["AI_assisted"],
+            ],
+        )
+        population.loc[ultrasound_index, COLUMNS.ULTRASOUND_TYPE] = ultrasound_type
+
+        # Get index groups for each ultrasound type
+        no_ultrasound_index = population.index[
+            population[COLUMNS.ULTRASOUND_TYPE] == "no_ultrasound"
+        ]
+        standard_ultrasound_index = population.index[
+            population[COLUMNS.ULTRASOUND_TYPE] == "standard"
+        ]
+        ai_ultrasound_index = population.index[
+            population[COLUMNS.ULTRASOUND_TYPE] == "AI_assisted"
+        ]
+
+        # Record the stated gestational age
+
+        # Record whether the child was successfully identified as low birth weight
+
+    def _get_location(self, builder: Builder) -> str:
+        return builder.data.load("population.location")

--- a/src/vivarium_gates_mncnh/components/antenatal_care.py
+++ b/src/vivarium_gates_mncnh/components/antenatal_care.py
@@ -53,9 +53,6 @@ class TreeMachine(Machine):
 
 
 class DecisionTreeState(State):
-    def setup(self, builder: Builder) -> None:
-        self._sim_step_name = builder.time.simulation_event_name()
-
     def add_decision(
         self,
         output_state: State,
@@ -63,22 +60,8 @@ class DecisionTreeState(State):
             1.0, index=index
         ),
     ) -> None:
-        transition = Transition(
-            self, output_state, self.get_probability_function(decision_function)
-        )
+        transition = Transition(self, output_state, decision_function)
         self.add_transition(transition)
-
-    def get_probability_function(
-        self, decision_function: Callable[[pd.Index], pd.Series]
-    ) -> Callable[[pd.Index], pd.Series]:
-        """We need to check the simulation step name within the probability function, because it will change"""
-
-        def probability_function(index: pd.Index) -> pd.Series:
-            if self._sim_step_name() != SIMULATION_EVENT_NAMES.PREGNANCY:
-                return lambda index: pd.Series(0.0, index=index)
-            return decision_function(index)
-
-        return probability_function
 
 
 class TransientDecisionTreeState(DecisionTreeState, Transient):

--- a/src/vivarium_gates_mncnh/components/antenatal_care.py
+++ b/src/vivarium_gates_mncnh/components/antenatal_care.py
@@ -136,6 +136,7 @@ def ANC() -> Machine:
     # Decisions
     initial_state.add_decision(
         attended_antental_care,
+        # TODO: this data will need to be updated when the ANC artifact is finished
         lambda index: pd.Series(
             ANC_RATES.ATTENDED_CARE_FACILITY[initial_state.location], index=index
         ),

--- a/src/vivarium_gates_mncnh/components/pregnancy.py
+++ b/src/vivarium_gates_mncnh/components/pregnancy.py
@@ -7,7 +7,11 @@ from vivarium_public_health.utilities import get_lookup_columns
 
 from vivarium_gates_mncnh.components.children import NewChildren
 from vivarium_gates_mncnh.constants import data_keys
-from vivarium_gates_mncnh.constants.data_values import DURATIONS, PREGNANCY_OUTCOMES
+from vivarium_gates_mncnh.constants.data_values import (
+    COLUMNS,
+    DURATIONS,
+    PREGNANCY_OUTCOMES,
+)
 from vivarium_gates_mncnh.constants.metadata import ARTIFACT_INDEX_COLUMNS
 
 
@@ -20,11 +24,11 @@ class Pregnancy(Component):
     @property
     def columns_created(self):
         return [
-            "pregnancy_outcome",
-            "pregnancy_duration",
-            "sex_of_child",
-            "birth_weight",
-            "gestational_age",  # Why repeated?
+            COLUMNS.PREGNANCY_OUTCOME,
+            COLUMNS.PREGNANCY_DURATION,
+            COLUMNS.GESTATIONAL_AGE,
+            COLUMNS.BIRTH_WEIGHT,
+            COLUMNS.SEX_OF_CHILD,
         ]
 
     @property

--- a/src/vivarium_gates_mncnh/constants/data_values.py
+++ b/src/vivarium_gates_mncnh/constants/data_values.py
@@ -71,11 +71,6 @@ INFANT_MALE_PERCENTAGES = {
     "Pakistan": 0.514583,
 }
 
-ANC_ULTRASOUND = {"Ethiopia": 0.607, "Nigeria": 0.587, "Pakistan": 0.667}
-
-ANC_AI_ULTRASOUND = {"Ethiopia": 0, "Nigeria": 0, "Pakistan": 0}
-
-STATED_GA_AT_ANC = {"no_ultrasound": 45.5, "standard_ultrasound": 20, "ai_ultrasound": 5}
 
 NUM_DRAWS = 500
 

--- a/src/vivarium_gates_mncnh/constants/data_values.py
+++ b/src/vivarium_gates_mncnh/constants/data_values.py
@@ -79,3 +79,49 @@ class _SimulationEventNames(NamedTuple):
 
 
 SIMULATION_EVENT_NAMES = _SimulationEventNames()
+
+
+class __ANCRates(NamedTuple):
+    ATTENDED_CARE_FACILITY = {
+        "Ethiopia": 0.757,
+        "Nigeria": 0.743,
+        "Pakistan": 0.908,
+    }
+    RECEIVED_ULTRASOUND = {
+        "Ethiopia": 0.607,
+        "Nigeria": 0.587,
+        "Pakistan": 0.667,
+    }
+    ULTRASOUND_TYPE = {
+        "standard": 0.75,
+        "AI_assisted": 0.25,
+    }
+    SUCCESSFUL_LBW_IDENTIFICATION = {
+        "no_ultrasound": 0.10,
+        "standard": 0.61,
+        "AI_assisted": 0.80,
+    }
+    STATED_GESTATIONAL_AGE_STANDARD_DEVIATION = {
+        "no_ultrasound": 45.5,
+        "standard": 20.0,
+        "AI_assisted": 5.0,
+    }
+
+
+ANC_RATES = __ANCRates()
+
+
+class __Columns(NamedTuple):
+    PREGNANCY_OUTCOME = "pregnancy_outcome"
+    PREGNANCY_DURATION = "pregnancy_duration"
+    SEX_OF_CHILD = "sex_of_child"
+    BIRTH_WEIGHT = "birth_weight"
+    GESTATIONAL_AGE = "gestational_age"
+    ATTENDED_CARE_FACILITY = "attended_care_facility"
+    RECEIVED_ULTRASOUND = "received_ultrasound"
+    ULTRASOUND_TYPE = "ultrasound_type"
+    STATED_GESTATIONAL_AGE = "stated_gestational_age"
+    SUCCESSFUL_LBW_IDENTIFICATION = "successful_lbw_identification"
+
+
+COLUMNS = __Columns()

--- a/src/vivarium_gates_mncnh/constants/data_values.py
+++ b/src/vivarium_gates_mncnh/constants/data_values.py
@@ -110,8 +110,18 @@ class __ANCRates(NamedTuple):
         "Pakistan": 0.667,
     }
     ULTRASOUND_TYPE = {
-        ULTRASOUND_TYPES.STANDARD: 0.75,
-        ULTRASOUND_TYPES.AI_ASSISTED: 0.25,
+        "Ethiopia": {
+            ULTRASOUND_TYPES.STANDARD: 1.0,
+            ULTRASOUND_TYPES.AI_ASSISTED: 0.0,
+        },
+        "Nigeria": {
+            ULTRASOUND_TYPES.STANDARD: 1.0,
+            ULTRASOUND_TYPES.AI_ASSISTED: 0.0,
+        },
+        "Pakistan": {
+            ULTRASOUND_TYPES.STANDARD: 1.0,
+            ULTRASOUND_TYPES.AI_ASSISTED: 0.0,
+        },
     }
     SUCCESSFUL_LBW_IDENTIFICATION = {
         ULTRASOUND_TYPES.NO_ULTRASOUND: 0.10,

--- a/src/vivarium_gates_mncnh/constants/data_values.py
+++ b/src/vivarium_gates_mncnh/constants/data_values.py
@@ -35,9 +35,11 @@ SCREENING_SCALE_UP_DIFFERENCE = (
 )
 
 
-#########################
-# Constat scalar values #
-#########################
+##########################
+# Constant scalar values #
+##########################
+
+# Threshold for children to be considered underweight (in grams)
 LOW_BIRTH_WEIGHT_THRESHOLD = 2500
 
 

--- a/src/vivarium_gates_mncnh/constants/data_values.py
+++ b/src/vivarium_gates_mncnh/constants/data_values.py
@@ -81,6 +81,15 @@ class _SimulationEventNames(NamedTuple):
 SIMULATION_EVENT_NAMES = _SimulationEventNames()
 
 
+class __UltrasoundTypes(NamedTuple):
+    STANDARD: str = "standard"
+    NO_ULTRASOUND: str = "no_ultrasound"
+    AI_ASSISTED: str = "AI_assisted"
+
+
+ULTRASOUND_TYPES = __UltrasoundTypes()
+
+
 class __ANCRates(NamedTuple):
     ATTENDED_CARE_FACILITY = {
         "Ethiopia": 0.757,
@@ -93,18 +102,18 @@ class __ANCRates(NamedTuple):
         "Pakistan": 0.667,
     }
     ULTRASOUND_TYPE = {
-        "standard": 0.75,
-        "AI_assisted": 0.25,
+        ULTRASOUND_TYPES.STANDARD: 0.75,
+        ULTRASOUND_TYPES.AI_ASSISTED: 0.25,
     }
     SUCCESSFUL_LBW_IDENTIFICATION = {
-        "no_ultrasound": 0.10,
-        "standard": 0.61,
-        "AI_assisted": 0.80,
+        ULTRASOUND_TYPES.NO_ULTRASOUND: 0.10,
+        ULTRASOUND_TYPES.STANDARD: 0.61,
+        ULTRASOUND_TYPES.AI_ASSISTED: 0.80,
     }
     STATED_GESTATIONAL_AGE_STANDARD_DEVIATION = {
-        "no_ultrasound": 45.5,
-        "standard": 20.0,
-        "AI_assisted": 5.0,
+        ULTRASOUND_TYPES.NO_ULTRASOUND: 45.5,
+        ULTRASOUND_TYPES.STANDARD: 20.0,
+        ULTRASOUND_TYPES.AI_ASSISTED: 5.0,
     }
 
 

--- a/src/vivarium_gates_mncnh/constants/data_values.py
+++ b/src/vivarium_gates_mncnh/constants/data_values.py
@@ -35,6 +35,12 @@ SCREENING_SCALE_UP_DIFFERENCE = (
 )
 
 
+#########################
+# Constat scalar values #
+#########################
+LOW_BIRTH_WEIGHT_THRESHOLD = 2500
+
+
 class __PregnancyOutcome(NamedTuple):
     PARTIAL_TERM_OUTCOME = "partial_term"
     LIVE_BIRTH_OUTCOME = "live_birth"
@@ -111,9 +117,9 @@ class __ANCRates(NamedTuple):
         ULTRASOUND_TYPES.AI_ASSISTED: 0.80,
     }
     STATED_GESTATIONAL_AGE_STANDARD_DEVIATION = {
-        ULTRASOUND_TYPES.NO_ULTRASOUND: 45.5,
-        ULTRASOUND_TYPES.STANDARD: 20.0,
-        ULTRASOUND_TYPES.AI_ASSISTED: 5.0,
+        ULTRASOUND_TYPES.NO_ULTRASOUND: 45.5 / 7,
+        ULTRASOUND_TYPES.STANDARD: 20.0 / 7,
+        ULTRASOUND_TYPES.AI_ASSISTED: 5.0 / 7,
     }
 
 

--- a/src/vivarium_gates_mncnh/data/builder.py
+++ b/src/vivarium_gates_mncnh/data/builder.py
@@ -9,6 +9,7 @@ Some degree of verbosity/boilerplate is fine in the interest of transparency.
    Logging in this module should be done at the ``debug`` level.
 
 """
+
 from pathlib import Path
 from typing import Optional
 

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -11,7 +11,6 @@ for an example.
 
    No logging is done here. Logging is done in vivarium inputs itself and forwarded.
 """
-import pdb
 from typing import List, Optional, Union
 
 import numpy as np

--- a/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
@@ -9,7 +9,6 @@ components:
         population:
             - BasePopulation()
 
-    # Causes an error if left empty. Uncomment when you have components. 
     vivarium_gates_mncnh:
         components:
             - Pregnancy()

--- a/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
@@ -19,7 +19,7 @@ components:
 configuration:
     input_data:
         input_draw_number: 0
-        artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/pregnancy/ethiopia.hdf"
+        artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/anc/ethiopia.hdf"
     interpolation:
         order: 0
         extrapolate: True

--- a/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
@@ -20,8 +20,7 @@ components:
 configuration:
     input_data:
         input_draw_number: 0
-        # artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/pregnancy/ethiopia.hdf"
-        artifact_path: "/home/albrja/scratch/artifacts/ethiopia.hdf"
+        artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/pregnancy/ethiopia.hdf"
     interpolation:
         order: 0
         extrapolate: True

--- a/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
@@ -15,11 +15,13 @@ components:
             - Pregnancy()
             - ResultsStratifier()
             - BirthObserver()
+            - AntenatalCare()
 
 configuration:
     input_data:
         input_draw_number: 0
-        artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/pregnancy/ethiopia.hdf"
+        # artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/pregnancy/ethiopia.hdf"
+        artifact_path: "/home/albrja/scratch/artifacts/ethiopia.hdf"
     interpolation:
         order: 0
         extrapolate: True

--- a/src/vivarium_gates_mncnh/tools/make_artifacts.py
+++ b/src/vivarium_gates_mncnh/tools/make_artifacts.py
@@ -6,6 +6,7 @@
    Use your best judgement.
 
 """
+
 import shutil
 import sys
 import time

--- a/src/vivarium_gates_mncnh/utilities.py
+++ b/src/vivarium_gates_mncnh/utilities.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 from loguru import logger
 from scipy import stats
+from vivarium.framework.engine import Builder
 from vivarium.framework.randomness import get_hash
 from vivarium_public_health.risks.data_transformations import pivot_categorical
 
@@ -176,3 +177,7 @@ def get_random_variable(draw: int, seeded_distribution: SeededDistribution) -> f
     seed, distribution = seeded_distribution
     np.random.seed(get_hash(f"{seed}_draw_{draw}"))
     return distribution.rvs()
+
+
+def get_location(builder: Builder) -> str:
+    return builder.data.load("population.location")

--- a/update_readme.py
+++ b/update_readme.py
@@ -1,6 +1,7 @@
 """ This script updates the README.rst file with the latest information about
 the project. It is intended to be run from the github "update README" workflow.
 """
+
 import json
 import re
 


### PR DESCRIPTION
## Albrja/mic 5289/anc component

### Add ANC component to walk through pregnancy decision tree
- *Category*: Feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5289
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_mncnh_portfolio/concept_model.html#id6

### Changes and notes
-subclasses vivarium components to have state machine operate as a decision tree
-records stated gestational age and lbw identification based on decision tree outcomes

### Verification and Testing
Successfully ran simulation and state table columns were updated correctly with correct proportions.

