### PR TITLE
Albrja/mic-5611/obstructed-labor-artifact

### DIFF
--- a/src/vivarium_gates_mncnh/constants/data_keys.py
+++ b/src/vivarium_gates_mncnh/constants/data_keys.py
@@ -121,6 +121,27 @@ class __MaternalHemorrhage(NamedTuple):
 MATERNAL_HEMORRHAGE = __MaternalHemorrhage()
 
 
+class __ObstructedLabor(NamedTuple):
+    # Keys that will be loaded into the artifact. must have a colon type declaration
+    RAW_INCIDENCE_RATE: str = (
+        "cause.maternal_obstructed_labor_and_uterine_rupture.incidence_rate"
+    )
+    CSMR: str = (
+        "cause.maternal_obstructed_labor_and_uterine_rupture.cause_specific_mortality_rate"
+    )
+
+    @property
+    def name(self):
+        return "obstructed_labor"
+
+    @property
+    def log_name(self):
+        return "obstructed labor"
+
+
+OBSTRUCTED_LABOR = __ObstructedLabor()
+
+
 MAKE_ARTIFACT_KEY_GROUPS = [
     POPULATION,
     # TODO: list all key groups here
@@ -129,4 +150,5 @@ MAKE_ARTIFACT_KEY_GROUPS = [
     ANC,
     MATERNAL_SEPSIS,
     MATERNAL_HEMORRHAGE,
+    OBSTRUCTED_LABOR,
 ]

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -69,6 +69,8 @@ def get_data(
         data_keys.MATERNAL_SEPSIS.CSMR: load_standard_data,
         data_keys.MATERNAL_HEMORRHAGE.RAW_INCIDENCE_RATE: load_standard_data,
         data_keys.MATERNAL_HEMORRHAGE.CSMR: load_standard_data,
+        data_keys.OBSTRUCTED_LABOR.RAW_INCIDENCE_RATE: load_standard_data,
+        data_keys.OBSTRUCTED_LABOR.CSMR: load_standard_data,
     }
     return mapping[lookup_key](lookup_key, location, years)
 


### PR DESCRIPTION
## Albrja/mic-5611/obstructed-labor-artifact

### Artifact for obstructed labor maternal disorder
- *Category*: Data artifact
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5611
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/causes/maternal_disorders/gbd_2021_mncnh/obstructed_labor.html#id5

### Changes and notes
-add data keys for obstructed labor

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

