### PR TITLE
Albrja/mic 5745/neonatal cause artifact

### DIFF
--- a/src/vivarium_gates_mncnh/constants/data_keys.py
+++ b/src/vivarium_gates_mncnh/constants/data_keys.py
@@ -164,7 +164,9 @@ PRETERM_BIRTH = __NeonatalPretermBirth()
 
 class __NeonatalSepsis(NamedTuple):
     # Keys that will be loaded into the artifact. must have a colon type declaration
-    CSMR: str = "cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_rate"
+    CSMR: str = (
+        "cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_rate"
+    )
 
     @property
     def name(self):

--- a/src/vivarium_gates_mncnh/constants/data_keys.py
+++ b/src/vivarium_gates_mncnh/constants/data_keys.py
@@ -16,6 +16,7 @@ class __Population(NamedTuple):
     DEMOGRAPHY: str = "population.demographic_dimensions"
     TMRLE: str = "population.theoretical_minimum_risk_life_expectancy"
     SCALING_FACTOR: str = "population.scaling_factor"
+    ACMR: str = "cause.all_causes.cause_specific_mortality_rate"
 
     @property
     def name(self):
@@ -145,6 +146,54 @@ class __ObstructedLabor(NamedTuple):
 OBSTRUCTED_LABOR = __ObstructedLabor()
 
 
+class __NeonatalPretermBirth(NamedTuple):
+    # Keys that will be loaded into the artifact. must have a colon type declaration
+    CSMR: str = "cause.neonatal_preterm_birth.cause_specific_mortality_rate"
+
+    @property
+    def name(self):
+        return "neonatal_preterm_birth"
+
+    @property
+    def log_name(self):
+        return "neonatal preterm birth"
+
+
+PRETERM_BIRTH = __NeonatalPretermBirth()
+
+
+class __NeonatalSepsis(NamedTuple):
+    # Keys that will be loaded into the artifact. must have a colon type declaration
+    CSMR: str = "cause.neonatal_neonatal_sepsis_and_other_neonatal_infectionssepsis.cause_specific_mortality_rate"
+
+    @property
+    def name(self):
+        return "neonatal_sepsis"
+
+    @property
+    def log_name(self):
+        return "neonatal sepsis"
+
+
+NEONATAL_SEPSIS = __NeonatalSepsis()
+
+
+class __NeonatalEncephalopath(NamedTuple):
+    # Keys that will be loaded into the artifact. must have a colon type declaration
+    CSMR: str = "cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_rate"
+
+    @property
+    def name(self):
+        return "neonatal_encephalopathy"
+
+    @property
+    def log_name(self):
+        return "neonatal encephalopathy"
+
+
+NEONATAL_ENCEPHALOPATHY = __NeonatalEncephalopath()
+
+
 MAKE_ARTIFACT_KEY_GROUPS = [
     POPULATION,
     # TODO: list all key groups here
@@ -154,4 +203,7 @@ MAKE_ARTIFACT_KEY_GROUPS = [
     MATERNAL_SEPSIS,
     MATERNAL_HEMORRHAGE,
     OBSTRUCTED_LABOR,
+    PRETERM_BIRTH,
+    NEONATAL_SEPSIS,
+    NEONATAL_ENCEPHALOPATHY,
 ]

--- a/src/vivarium_gates_mncnh/constants/data_keys.py
+++ b/src/vivarium_gates_mncnh/constants/data_keys.py
@@ -164,7 +164,7 @@ PRETERM_BIRTH = __NeonatalPretermBirth()
 
 class __NeonatalSepsis(NamedTuple):
     # Keys that will be loaded into the artifact. must have a colon type declaration
-    CSMR: str = "cause.neonatal_neonatal_sepsis_and_other_neonatal_infectionssepsis.cause_specific_mortality_rate"
+    CSMR: str = "cause.neonatal_sepsis_and_other_neonatal_infectionssepsis.cause_specific_mortality_rate"
 
     @property
     def name(self):

--- a/src/vivarium_gates_mncnh/constants/data_keys.py
+++ b/src/vivarium_gates_mncnh/constants/data_keys.py
@@ -164,7 +164,7 @@ PRETERM_BIRTH = __NeonatalPretermBirth()
 
 class __NeonatalSepsis(NamedTuple):
     # Keys that will be loaded into the artifact. must have a colon type declaration
-    CSMR: str = "cause.neonatal_sepsis_and_other_neonatal_infectionssepsis.cause_specific_mortality_rate"
+    CSMR: str = "cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_rate"
 
     @property
     def name(self):

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -56,7 +56,7 @@ def get_data(
         data_keys.POPULATION.DEMOGRAPHY: load_demographic_dimensions,
         data_keys.POPULATION.TMRLE: load_theoretical_minimum_risk_life_expectancy,
         data_keys.POPULATION.SCALING_FACTOR: load_scaling_factor,
-        # data_keys.POPULATION.ACMR: load_standard_data,
+        data_keys.POPULATION.ACMR: load_standard_data,
         # TODO - add appropriate mappings
         data_keys.PREGNANCY.ASFR: load_asfr,
         data_keys.PREGNANCY.SBR: load_sbr,
@@ -75,6 +75,9 @@ def get_data(
         data_keys.OBSTRUCTED_LABOR.RAW_INCIDENCE_RATE: load_standard_data,
         data_keys.OBSTRUCTED_LABOR.CSMR: load_standard_data,
         data_keys.OBSTRUCTED_LABOR.YLD_RATE: load_maternal_disorder_yld_rate,
+        data_keys.PRETERM_BIRTH.CSMR: load_standard_data,
+        data_keys.NEONATAL_SEPSIS.CSMR: load_standard_data,
+        data_keys.NEONATAL_ENCEPHALOPATHY.CSMR: load_standard_data,
     }
     return mapping[lookup_key](lookup_key, location, years)
 


### PR DESCRIPTION
## Albrja/mic 5745/neonatal cause artifact

### Neonatal subcause artifact
- *Category*: Data artifact
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5745
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/causes/neonatal/neonatal_sepsis.html#id6

### Changes and notes
-Add all cause mortality to artifact
-add CSMR for each neonatal subcause

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

