### PR TITLE
Albrja/mic 5859/bugfix/preterm death counts

### DIFF
--- a/src/vivarium_gates_mncnh/components/children.py
+++ b/src/vivarium_gates_mncnh/components/children.py
@@ -65,11 +65,7 @@ class LBWSGDistribution(Component):
         exposure = builder.data.load(data_keys.LBWSG.EXPOSURE).rename(
             columns=data_values.CHILD_LOOKUP_COLUMN_MAPPER
         )
-        # Subset to early neonatal for birth prevalence group
-        birth_prevalence_exposure = exposure.loc[
-            exposure["child_age_end"] < 8 / 365.0
-        ].set_index(data_values.COLUMNS.SEX_OF_CHILD)
-        return birth_prevalence_exposure
+        breakpoint()
 
     def get_exposure(self, newborn_sex: pd.Series):
         categorical_exposure = self._sample_categorical_exposure(newborn_sex)

--- a/src/vivarium_gates_mncnh/components/children.py
+++ b/src/vivarium_gates_mncnh/components/children.py
@@ -67,6 +67,8 @@ class LBWSGDistribution(Component):
             .rename(columns=data_values.CHILD_LOOKUP_COLUMN_MAPPER)
             .set_index(data_values.COLUMNS.SEX_OF_CHILD)
         )
+        # Subset to birth age group
+        exposure = exposure[exposure["child_age_start"] < 0.0]
         return exposure
 
     def get_exposure(self, newborn_sex: pd.Series):

--- a/src/vivarium_gates_mncnh/components/children.py
+++ b/src/vivarium_gates_mncnh/components/children.py
@@ -62,10 +62,12 @@ class LBWSGDistribution(Component):
         self.category_intervals = self._get_category_intervals(builder)
 
     def _load_exposure_data(self, builder: Builder) -> pd.DataFrame:
-        exposure = builder.data.load(data_keys.LBWSG.EXPOSURE).rename(
-            columns=data_values.CHILD_LOOKUP_COLUMN_MAPPER
+        exposure = (
+            builder.data.load(data_keys.LBWSG.EXPOSURE)
+            .rename(columns=data_values.CHILD_LOOKUP_COLUMN_MAPPER)
+            .set_index(data_values.COLUMNS.SEX_OF_CHILD)
         )
-        breakpoint()
+        return exposure
 
     def get_exposure(self, newborn_sex: pd.Series):
         categorical_exposure = self._sample_categorical_exposure(newborn_sex)

--- a/src/vivarium_gates_mncnh/components/children.py
+++ b/src/vivarium_gates_mncnh/components/children.py
@@ -5,7 +5,7 @@ import pandas as pd
 from vivarium import Component
 from vivarium.framework.engine import Builder
 
-from vivarium_gates_mncnh.constants import data_keys, data_values, models
+from vivarium_gates_mncnh.constants import data_keys, data_values
 
 
 class NewChildren(Component):
@@ -58,8 +58,18 @@ class NewChildren(Component):
 class LBWSGDistribution(Component):
     def setup(self, builder: Builder):
         self.randomness = builder.randomness.get_stream(self.name)
-        self.exposure = builder.data.load(data_keys.LBWSG.EXPOSURE).set_index("sex")
+        self.exposure = self._load_exposure_data(builder)
         self.category_intervals = self._get_category_intervals(builder)
+
+    def _load_exposure_data(self, builder: Builder) -> pd.DataFrame:
+        exposure = builder.data.load(data_keys.LBWSG.EXPOSURE).rename(
+            columns=data_values.CHILD_LOOKUP_COLUMN_MAPPER
+        )
+        # Subset to early neonatal for birth prevalence group
+        birth_prevalence_exposure = exposure.loc[
+            exposure["child_age_end"] < 8 / 365.0
+        ].set_index(data_values.COLUMNS.SEX_OF_CHILD)
+        return birth_prevalence_exposure
 
     def get_exposure(self, newborn_sex: pd.Series):
         categorical_exposure = self._sample_categorical_exposure(newborn_sex)

--- a/src/vivarium_gates_mncnh/components/lbwsg.py
+++ b/src/vivarium_gates_mncnh/components/lbwsg.py
@@ -77,14 +77,14 @@ class LBWSGRiskEffect(LBWSGRiskEffect_):
 
     def get_age_intervals(self, builder: Builder) -> dict[str, pd.Interval]:
         age_bins = builder.data.load("population.age_bins").set_index("age_start")
-        exposure = builder.data.load(f"{self.risk}.relative_risk")
+        relative_risks = builder.data.load(f"{self.risk}.relative_risk")
         # Map to child columns
         age_bins = age_bins.rename(columns=CHILD_LOOKUP_COLUMN_MAPPER)
-        exposure = exposure.rename(columns=CHILD_LOOKUP_COLUMN_MAPPER)
-        exposure = exposure[exposure["child_age_end"] > 0]
+        relative_risks = relative_risks.rename(columns=CHILD_LOOKUP_COLUMN_MAPPER)
+        relative_risks = relative_risks[relative_risks["child_age_end"] > 0]
 
         exposed_age_group_starts = (
-            exposure.groupby("child_age_start")["value"]
+            relative_risks.groupby("child_age_start")["value"]
             .any()
             .reset_index()["child_age_start"]
         )

--- a/src/vivarium_gates_mncnh/components/lbwsg.py
+++ b/src/vivarium_gates_mncnh/components/lbwsg.py
@@ -77,7 +77,7 @@ class LBWSGRiskEffect(LBWSGRiskEffect_):
 
     def get_age_intervals(self, builder: Builder) -> dict[str, pd.Interval]:
         age_bins = builder.data.load("population.age_bins").set_index("age_start")
-        exposure = builder.data.load(f"{self.risk}.exposure")
+        exposure = builder.data.load(f"{self.risk}.relative_risk")
         # Map to child columns
         age_bins = age_bins.rename(columns=CHILD_LOOKUP_COLUMN_MAPPER)
         exposure = exposure.rename(columns=CHILD_LOOKUP_COLUMN_MAPPER)

--- a/src/vivarium_gates_mncnh/components/lbwsg.py
+++ b/src/vivarium_gates_mncnh/components/lbwsg.py
@@ -82,7 +82,6 @@ class LBWSGRiskEffect(LBWSGRiskEffect_):
         age_bins = age_bins.rename(columns=CHILD_LOOKUP_COLUMN_MAPPER)
         exposure = exposure.rename(columns=CHILD_LOOKUP_COLUMN_MAPPER)
         exposure = exposure[exposure["child_age_end"] > 0]
-        #
 
         exposed_age_group_starts = (
             exposure.groupby("child_age_start")["value"]

--- a/src/vivarium_gates_mncnh/components/lbwsg.py
+++ b/src/vivarium_gates_mncnh/components/lbwsg.py
@@ -81,7 +81,6 @@ class LBWSGRiskEffect(LBWSGRiskEffect_):
         # Map to child columns
         age_bins = age_bins.rename(columns=CHILD_LOOKUP_COLUMN_MAPPER)
         relative_risks = relative_risks.rename(columns=CHILD_LOOKUP_COLUMN_MAPPER)
-        relative_risks = relative_risks[relative_risks["child_age_end"] > 0]
 
         exposed_age_group_starts = (
             relative_risks.groupby("child_age_start")["value"]

--- a/src/vivarium_gates_mncnh/data/extra_gbd.py
+++ b/src/vivarium_gates_mncnh/data/extra_gbd.py
@@ -23,3 +23,20 @@ def get_maternal_disorder_yld_rate(key: str, location: str) -> pd.DataFrame:
         metric_id=vi_globals.METRICS["Rate"],
     )
     return data
+
+
+@gbd.memory.cache
+def load_lbwsg_exposure(location: str):
+    entity = utilities.get_entity(data_keys.LBWSG.EXPOSURE)
+    location_id = utility_data.get_location_id(location)
+    data = vi_utils.get_draws(
+        gbd_id_type="rei_id",
+        gbd_id=entity.gbd_id,
+        source=gbd_constants.SOURCES.EXPOSURE,
+        location_id=location_id,
+        year_id=2021,
+        sex_id=gbd_constants.SEX.MALE + gbd_constants.SEX.FEMALE,
+        age_group_id=164,  # Birth prevalence
+        release_id=gbd_constants.RELEASE_IDS.GBD_2021,
+    )
+    return data

--- a/src/vivarium_gates_mncnh/data/extra_gbd.py
+++ b/src/vivarium_gates_mncnh/data/extra_gbd.py
@@ -25,7 +25,7 @@ def get_maternal_disorder_yld_rate(key: str, location: str) -> pd.DataFrame:
     return data
 
 
-@gbd.memory.cache
+@vi_utils.cache
 def load_lbwsg_exposure(location: str):
     entity = utilities.get_entity(data_keys.LBWSG.EXPOSURE)
     location_id = utility_data.get_location_id(location)

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -416,7 +416,8 @@ def load_lbwsg_paf(
 def load_lbwsg_exposure(
     key: str, location: str, years: Optional[Union[int, str, List[int]]] = None
 ) -> pd.DataFrame:
-
+    
+    entity = get_entity(data_keys.LBWSG.EXPOSURE)
     data = extra_gbd.load_lbwsg_exposure(location)
     # This category was a mistake in GBD 2019, so drop.
     extra_residual_category = vi_globals.EXTRA_RESIDUAL_CATEGORY[entity.name]

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -417,8 +417,8 @@ def load_lbwsg_exposure(
     key: str, location: str, years: Optional[Union[int, str, List[int]]] = None
 ) -> pd.DataFrame:
     
-    entity = get_entity(data_keys.LBWSG.EXPOSURE)
-    data = extra_gbd.load_lbwsg_exposure(location)
+    entity = utilities.get_entity(data_keys.LBWSG.EXPOSURE)
+    data = extra_gbd.load_lbwsg_exposure(location)  
     # This category was a mistake in GBD 2019, so drop.
     extra_residual_category = vi_globals.EXTRA_RESIDUAL_CATEGORY[entity.name]
     data = data.loc[data["parameter"] != extra_residual_category]

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -445,7 +445,7 @@ def load_lbwsg_exposure(
 
     # normalize so all categories sum to 1
     total_exposure = exposure.groupby(["age_start", "age_end", "sex"]).transform("sum")
-    exposure = (exposure / total_exposure).reset_index().set_index(idx_cols)
+    exposure = (exposure / total_exposure).reset_index().set_index(idx_cols).sort_index()
     return exposure
 
 

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -66,7 +66,7 @@ def get_data(
         data_keys.PREGNANCY.RAW_INCIDENCE_RATE_ECTOPIC: load_raw_incidence_data,
         data_keys.LBWSG.DISTRIBUTION: load_metadata,
         data_keys.LBWSG.CATEGORIES: load_metadata,
-        data_keys.LBWSG.EXPOSURE: load_standard_data,
+        data_keys.LBWSG.EXPOSURE: load_lbwsg_exposure,
         data_keys.LBWSG.RELATIVE_RISK: load_lbwsg_rr,
         data_keys.LBWSG.RELATIVE_RISK_INTERPOLATOR: load_lbwsg_interpolated_rr,
         data_keys.LBWSG.PAF: load_lbwsg_paf,
@@ -411,6 +411,28 @@ def load_lbwsg_paf(
             df.loc[(sex, age_start, age_end, 2021, 2022), :] = 0
 
     return df.sort_index()
+
+
+def load_lbwsg_exposure(
+    location: str, years: Optional[Union[int, str, List[int]]] = None
+) -> pd.DataFrame:
+
+    data = extra_gbd.load_lbwsg_exposure(location)
+    # This category was a mistake in GBD 2019, so drop.
+    extra_residual_category = vi_globals.EXTRA_RESIDUAL_CATEGORY[entity.name]
+    data = data.loc[data["parameter"] != extra_residual_category]
+    idx_cols = ["location_id", "sex_id", "parameter"]
+    data = data.set_index(idx_cols)[vi_globals.DRAW_COLUMNS]
+
+    # Sometimes there are data values on the order of 10e-300 that cause
+    # floating point headaches, so clip everything to reasonable values
+    data = data.clip(lower=vi_globals.MINIMUM_EXPOSURE_VALUE)
+
+    # normalize so all categories sum to 1
+    total_exposure = data.groupby(["location_id", "sex_id"]).transform("sum")
+    data = (data / total_exposure).reset_index()
+    data = reshape_to_vivarium_format(data, location)
+    return data
 
 
 def reshape_to_vivarium_format(df, location):

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -417,11 +417,36 @@ def load_lbwsg_exposure(
     key: str, location: str, years: Optional[Union[int, str, List[int]]] = None
 ) -> pd.DataFrame:
 
+    if key != data_keys.LBWSG.EXPOSURE:
+        raise ValueError(f"Unrecognized key {key}")
+
+    # Get exposure for all age groups except birth age group
+    all_age_exposure = load_standard_data(key, location, years)
+
     entity = utilities.get_entity(data_keys.LBWSG.EXPOSURE)
-    data = extra_gbd.load_lbwsg_exposure(location)
-    normalized_exposure = utilities.rescale_prevalence(data)
-    cleaned_data = reshape_to_vivarium_format(normalized_exposure, location)
-    return cleaned_data
+    birth_exposure = extra_gbd.load_lbwsg_exposure(location)
+    # This category was a mistake in GBD 2019, so drop.
+    extra_residual_category = vi_globals.EXTRA_RESIDUAL_CATEGORY[entity.name]
+    birth_exposure = birth_exposure.loc[
+        birth_exposure["parameter"] != extra_residual_category
+    ]
+    birth_exposure = birth_exposure.set_index(
+        ["location_id", "age_group_id", "year_id", "sex_id", "parameter"]
+    )[vi_globals.DRAW_COLUMNS]
+    # Sometimes there are data values on the order of 10e-300 that cause
+    # floating point headaches, so clip everything to reasonable values
+    birth_exposure = birth_exposure.clip(lower=vi_globals.MINIMUM_EXPOSURE_VALUE)
+    birth_exposure = reshape_to_vivarium_format(birth_exposure, location)
+    birth_exposure["age_start"] = (0 - 7) / 365.0
+    birth_exposure["age_end"] = 0.0
+    idx_cols = ["age_start", "age_end", "year_id", "sex_id", "parameter"]
+    exposure = pd.concat([all_age_exposure.reset_index(), birth_exposure.reset_index()])
+    exposure = exposure.set_index(idx_cols)[vi_globals.DRAW_COLUMNS]
+
+    # normalize so all categories sum to 1
+    total_exposure = exposure.groupby(["age_start", "age_end", "sex_id"]).transform("sum")
+    exposure = (exposure / total_exposure).reset_index().set_index(idx_cols)
+    return exposure
 
 
 def reshape_to_vivarium_format(df, location):

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -416,24 +416,12 @@ def load_lbwsg_paf(
 def load_lbwsg_exposure(
     key: str, location: str, years: Optional[Union[int, str, List[int]]] = None
 ) -> pd.DataFrame:
-    
+
     entity = utilities.get_entity(data_keys.LBWSG.EXPOSURE)
-    data = extra_gbd.load_lbwsg_exposure(location)  
-    # This category was a mistake in GBD 2019, so drop.
-    extra_residual_category = vi_globals.EXTRA_RESIDUAL_CATEGORY[entity.name]
-    data = data.loc[data["parameter"] != extra_residual_category]
-    idx_cols = ["location_id", "sex_id", "parameter"]
-    data = data.set_index(idx_cols)[vi_globals.DRAW_COLUMNS]
-
-    # Sometimes there are data values on the order of 10e-300 that cause
-    # floating point headaches, so clip everything to reasonable values
-    data = data.clip(lower=vi_globals.MINIMUM_EXPOSURE_VALUE)
-
-    # normalize so all categories sum to 1
-    total_exposure = data.groupby(["location_id", "sex_id"]).transform("sum")
-    data = (data / total_exposure).reset_index()
-    data = reshape_to_vivarium_format(data, location)
-    return data
+    data = extra_gbd.load_lbwsg_exposure(location)
+    normalized_exposure = utilities.rescale_prevalence(data)
+    cleaned_data = reshape_to_vivarium_format(normalized_exposure, location)
+    return cleaned_data
 
 
 def reshape_to_vivarium_format(df, location):

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -439,12 +439,12 @@ def load_lbwsg_exposure(
     birth_exposure = reshape_to_vivarium_format(birth_exposure, location).reset_index()
     birth_exposure["age_start"] = (0 - 7) / 365.0
     birth_exposure["age_end"] = 0.0
-    idx_cols = ["age_start", "age_end", "year_id", "sex_id", "parameter"]
+    idx_cols = ["sex", "age_start", "age_end", "year_start", "year_end", "parameter"]
     exposure = pd.concat([all_age_exposure.reset_index(), birth_exposure])
     exposure = exposure.set_index(idx_cols)[vi_globals.DRAW_COLUMNS]
 
     # normalize so all categories sum to 1
-    total_exposure = exposure.groupby(["age_start", "age_end", "sex_id"]).transform("sum")
+    total_exposure = exposure.groupby(["age_start", "age_end", "sex"]).transform("sum")
     exposure = (exposure / total_exposure).reset_index().set_index(idx_cols)
     return exposure
 

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -414,7 +414,7 @@ def load_lbwsg_paf(
 
 
 def load_lbwsg_exposure(
-    location: str, years: Optional[Union[int, str, List[int]]] = None
+    key: str, location: str, years: Optional[Union[int, str, List[int]]] = None
 ) -> pd.DataFrame:
 
     data = extra_gbd.load_lbwsg_exposure(location)

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -436,11 +436,11 @@ def load_lbwsg_exposure(
     # Sometimes there are data values on the order of 10e-300 that cause
     # floating point headaches, so clip everything to reasonable values
     birth_exposure = birth_exposure.clip(lower=vi_globals.MINIMUM_EXPOSURE_VALUE)
-    birth_exposure = reshape_to_vivarium_format(birth_exposure, location)
+    birth_exposure = reshape_to_vivarium_format(birth_exposure, location).reset_index()
     birth_exposure["age_start"] = (0 - 7) / 365.0
     birth_exposure["age_end"] = 0.0
     idx_cols = ["age_start", "age_end", "year_id", "sex_id", "parameter"]
-    exposure = pd.concat([all_age_exposure.reset_index(), birth_exposure.reset_index()])
+    exposure = pd.concat([all_age_exposure.reset_index(), birth_exposure])
     exposure = exposure.set_index(idx_cols)[vi_globals.DRAW_COLUMNS]
 
     # normalize so all categories sum to 1

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -431,7 +431,7 @@ def load_lbwsg_exposure(
         birth_exposure["parameter"] != extra_residual_category
     ]
     birth_exposure = birth_exposure.set_index(
-        ["location_id", "age_group_id", "year_id", "sex_id", "parameter"]
+        ["location_id", "year_id", "sex_id", "parameter"]
     )[vi_globals.DRAW_COLUMNS]
     # Sometimes there are data values on the order of 10e-300 that cause
     # floating point headaches, so clip everything to reasonable values

--- a/src/vivarium_gates_mncnh/data/utilities.py
+++ b/src/vivarium_gates_mncnh/data/utilities.py
@@ -66,20 +66,3 @@ def parse_short_gestation_description(description: str) -> pd.Interval:
         ]
     )
     return endpoints
-
-
-def rescale_prevalence(exposure):
-    """Rescales prevalences to add to 1 in LBWSG exposure data pulled from GBD 2019 by get_draws."""
-    # Drop residual 'cat125' parameter with meid==NaN, and convert meid col from float to int
-    exposure = exposure.dropna().astype({"modelable_entity_id": int})
-    # Define some categories of columns
-    draw_cols = exposure.filter(regex=r"^draw_\d{1,3}$").columns.to_list()
-    category_cols = ["modelable_entity_id", "parameter"]
-    index_cols = exposure.columns.difference(draw_cols)
-    sum_index = index_cols.difference(category_cols)
-    # Add prevalences over categories (indexed by meid and/or parameter) to get denominator for rescaling
-    prevalence_sum = exposure.groupby(sum_index.to_list())[draw_cols].sum()
-    # Divide prevalences by total to rescale them to add to 1, and reset index to put df back in original form
-    exposure = exposure.set_index(index_cols.to_list()) / prevalence_sum
-    exposure.reset_index(inplace=True)
-    return exposure

--- a/src/vivarium_gates_mncnh/data/utilities.py
+++ b/src/vivarium_gates_mncnh/data/utilities.py
@@ -66,3 +66,20 @@ def parse_short_gestation_description(description: str) -> pd.Interval:
         ]
     )
     return endpoints
+
+
+def rescale_prevalence(exposure):
+    """Rescales prevalences to add to 1 in LBWSG exposure data pulled from GBD 2019 by get_draws."""
+    # Drop residual 'cat125' parameter with meid==NaN, and convert meid col from float to int
+    exposure = exposure.dropna().astype({"modelable_entity_id": int})
+    # Define some categories of columns
+    draw_cols = exposure.filter(regex=r"^draw_\d{1,3}$").columns.to_list()
+    category_cols = ["modelable_entity_id", "parameter"]
+    index_cols = exposure.columns.difference(draw_cols)
+    sum_index = index_cols.difference(category_cols)
+    # Add prevalences over categories (indexed by meid and/or parameter) to get denominator for rescaling
+    prevalence_sum = exposure.groupby(sum_index.to_list())[draw_cols].sum()
+    # Divide prevalences by total to rescale them to add to 1, and reset index to put df back in original form
+    exposure = exposure.set_index(index_cols.to_list()) / prevalence_sum
+    exposure.reset_index(inplace=True)
+    return exposure

--- a/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
@@ -39,7 +39,7 @@ components:
 configuration:
     input_data:
         input_draw_number: 0
-        artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/neonatal/ethiopia.hdf"
+        artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/lbwsg/ethiopia.hdf"
     interpolation:
         order: 0
         extrapolate: True


### PR DESCRIPTION
## Albrja/mic 5859/bugfix/preterm death counts

### Update artifact data and and usage of LBWSG exposure 
- *Category*: Bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5859
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
-adds birth age group to LBWSG exposure data
-only uses birth age group for LBWSGDistribution component when generating children in the state table

### Verification and Testing
-Proportion of preterm simulants is within expected range
