### PR TITLE
Albrja/mic-5887/bugfix/neonatal-burden-observer

### DIFF
--- a/src/vivarium_gates_mncnh/components/observers.py
+++ b/src/vivarium_gates_mncnh/components/observers.py
@@ -314,7 +314,7 @@ class NeonatalBurdenObserver(BurdenObserver):
             )
 
     def to_observe(self, event: Event) -> bool:
-        # Only observer deaths after both neonatal periods to not double count ENN deaths.
+        # Need to make single observeration of deaths after all time steps where neonates die.
         return self._sim_step_name() == SIMULATION_EVENT_NAMES.LATE_NEONATAL_MORTALITY
 
 

--- a/src/vivarium_gates_mncnh/components/observers.py
+++ b/src/vivarium_gates_mncnh/components/observers.py
@@ -314,9 +314,8 @@ class NeonatalBurdenObserver(BurdenObserver):
             )
 
     def to_observe(self, event: Event) -> bool:
-        return (self._sim_step_name() == SIMULATION_EVENT_NAMES.EARLY_NEONATAL_MORTALITY) or (
-            self._sim_step_name() == SIMULATION_EVENT_NAMES.LATE_NEONATAL_MORTALITY
-        )
+        # Only observer deaths after both neonatal periods to not double count ENN deaths.
+        return self._sim_step_name() == SIMULATION_EVENT_NAMES.LATE_NEONATAL_MORTALITY
 
 
 class NeonatalCauseRelativeRiskObserver(Observer):

--- a/src/vivarium_gates_mncnh/components/pregnancy.py
+++ b/src/vivarium_gates_mncnh/components/pregnancy.py
@@ -102,9 +102,6 @@ class Pregnancy(Component):
             == PREGNANCY_OUTCOMES.LIVE_BIRTH_OUTCOME
         ]
         pregnancy_outcomes_and_durations.loc[live_birth_index, COLUMNS.CHILD_ALIVE] = "alive"
-        pregnancy_outcomes_and_durations.loc[
-            live_birth_index, COLUMNS.CHILD_AGE
-        ] = CHILD_INITIALIZATION_AGE
 
         self.population_view.update(pregnancy_outcomes_and_durations)
 


### PR DESCRIPTION
## Albrja/mic-5887/bugfix/neonatal-burden-observer

### Fix bug in observer double counting neonatal deaths
- *Category*: Bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5887
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
-fix bug to only record ENN deaths on one time step

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

