### PR TITLE
Albrja/mic 5972/lbwsg birth exposure

### DIFF
--- a/src/vivarium_gates_mncnh/components/lbwsg.py
+++ b/src/vivarium_gates_mncnh/components/lbwsg.py
@@ -10,6 +10,7 @@ from vivarium.component import Component
 from vivarium.framework.engine import Builder
 from vivarium.framework.lookup import LookupTable
 from vivarium.framework.population import SimulantData
+from vivarium.framework.resource import Resource
 from vivarium.framework.values import Pipeline
 from vivarium_public_health.risks.data_transformations import (
     get_exposure_post_processor,
@@ -56,17 +57,17 @@ class LBWSGRisk(LBWSGRisk_):
     # Point to the subclass of LBWSGDistribution
     exposure_distributions = {"lbwsg": LBWSGDistribution}
 
-    @property
-    def columns_required(self) -> list[str]:
-        return [COLUMNS.SEX_OF_CHILD, COLUMNS.CHILD_AGE]
+    # @property
+    # def columns_required(self) -> list[str]:
+    #     return [COLUMNS.SEX_OF_CHILD,]
 
-    @property
-    def initialization_requirements(self) -> dict[str, list[str]]:
-        return {
-            "requires_columns": [COLUMNS.SEX_OF_CHILD, COLUMNS.CHILD_AGE],
-            "requires_values": [],
-            "requires_streams": [],
-        }
+    # @property
+    # def initialization_requirements(self) -> dict[str, list[str]]:
+    #     return {
+    #         "requires_columns": [COLUMNS.SEX_OF_CHILD, COLUMNS.CHILD_AGE],
+    #         "requires_values": [],
+    #         "requires_streams": [],
+    #     }
 
 
 class LBWSGRiskEffect(LBWSGRiskEffect_):
@@ -80,13 +81,8 @@ class LBWSGRiskEffect(LBWSGRiskEffect_):
         return [COLUMNS.CHILD_AGE, COLUMNS.SEX_OF_CHILD] + self.lbwsg_exposure_column_names
 
     @property
-    def initialization_requirements(self) -> dict[str, list[str]]:
-        return {
-            "requires_columns": [COLUMNS.SEX_OF_CHILD, COLUMNS.CHILD_AGE]
-            + self.lbwsg_exposure_column_names,
-            "requires_values": [],
-            "requires_streams": [],
-        }
+    def initialization_requirements(self) -> list[str | Resource]:
+        return [COLUMNS.SEX_OF_CHILD] + self.lbwsg_exposure_column_names
 
     def setup(self, builder: Builder) -> None:
         # Paf pipeline needs to be registered before the super setup is called

--- a/src/vivarium_gates_mncnh/components/lbwsg.py
+++ b/src/vivarium_gates_mncnh/components/lbwsg.py
@@ -15,10 +15,6 @@ from vivarium.framework.values import Pipeline
 from vivarium_public_health.risks.data_transformations import (
     get_exposure_post_processor,
 )
-from vivarium_public_health.risks.distributions import RiskExposureDistribution
-from vivarium_public_health.risks.implementations.low_birth_weight_and_short_gestation import (
-    LBWSGDistribution as LBWSGDistribution_,
-)
 from vivarium_public_health.risks.implementations.low_birth_weight_and_short_gestation import (
     LBWSGRisk as LBWSGRisk_,
 )
@@ -42,32 +38,18 @@ BIRTH_WEIGHT = "birth_weight"
 GESTATIONAL_AGE = "gestational_age"
 
 
-class LBWSGDistribution(LBWSGDistribution_):
-    def get_exposure_data(self, builder: Builder) -> int | float | pd.DataFrame:
-        if self._exposure_data is not None:
-            return self._exposure_data
-        data = self.get_data(builder, self.configuration["data_sources"]["exposure"])
-        renamed_data = data.rename(columns=CHILD_LOOKUP_COLUMN_MAPPER)
-
-        return renamed_data
-
-
 class LBWSGRisk(LBWSGRisk_):
+    @property
+    def columns_required(self) -> list[str]:
+        return [
+            COLUMNS.SEX_OF_CHILD,
+        ]
 
-    # Point to the subclass of LBWSGDistribution
-    exposure_distributions = {"lbwsg": LBWSGDistribution}
-
-    # @property
-    # def columns_required(self) -> list[str]:
-    #     return [COLUMNS.SEX_OF_CHILD,]
-
-    # @property
-    # def initialization_requirements(self) -> dict[str, list[str]]:
-    #     return {
-    #         "requires_columns": [COLUMNS.SEX_OF_CHILD, COLUMNS.CHILD_AGE],
-    #         "requires_values": [],
-    #         "requires_streams": [],
-    #     }
+    @property
+    def initialization_requirements(self) -> list[str | Resource]:
+        return [
+            COLUMNS.SEX_OF_CHILD,
+        ]
 
 
 class LBWSGRiskEffect(LBWSGRiskEffect_):
@@ -253,6 +235,17 @@ class LBWSGPAFCalculationExposure(LBWSGRisk_):
             "lbwsg_category",
             "age_bin",
         ]
+
+    @property
+    def configuration_defaults(self) -> dict[str, Any]:
+        configuration_defaults = super().configuration_defaults
+        # Use the exposure for neonatal age groups instead of birth exposure
+        # TODO: remove when VPH is updated to handle this behavior
+        configuration_defaults[self.name]["data_sources"][
+            "exposure"
+        ] = f"{self.risk}.exposure"
+        configuration_defaults[self.name]["distribution_type"] = "lbwsg"
+        return configuration_defaults
 
     def setup(self, builder: Builder) -> None:
         super().setup(builder)

--- a/src/vivarium_gates_mncnh/components/observers.py
+++ b/src/vivarium_gates_mncnh/components/observers.py
@@ -15,6 +15,7 @@ from vivarium_gates_mncnh.constants.data_values import (
     COLUMNS,
     DELIVERY_FACILITY_TYPES,
     MATERNAL_DISORDERS,
+    PIPELINES,
     PREGNANCY_OUTCOMES,
     SIMULATION_EVENT_NAMES,
 )
@@ -158,10 +159,10 @@ class ANCObserver(Observer):
                 COLUMNS.MOTHER_AGE,
                 COLUMNS.ATTENDED_CARE_FACILITY,
                 COLUMNS.ULTRASOUND_TYPE,
-                COLUMNS.GESTATIONAL_AGE_EXPOSURE,
                 COLUMNS.STATED_GESTATIONAL_AGE,
                 COLUMNS.PREGNANCY_OUTCOME,
             ],
+            requires_values=[PIPELINES.PREGNANCY_DURATION],
             to_observe=self.to_observe,
         )
 

--- a/src/vivarium_gates_mncnh/components/pregnancy.py
+++ b/src/vivarium_gates_mncnh/components/pregnancy.py
@@ -31,6 +31,10 @@ class Pregnancy(Component):
         ]
 
     @property
+    def columns_required(self):
+        return [COLUMNS.GESTATIONAL_AGE_EXPOSURE]
+
+    @property
     def sub_components(self):
         return super().sub_components + [self.new_children]
 
@@ -59,9 +63,6 @@ class Pregnancy(Component):
                 [self.lookup_tables["birth_outcome_probabilities"]]
             ),
         )
-        self.gestational_age_pipeline = builder.value.get_value(
-            PIPELINES.GESTATIONAL_AGE_EXPOSURE
-        )
         self.pregnancy_durations = builder.value.register_value_producer(
             PIPELINES.PREGNANCY_DURATION,
             self.get_pregnancy_durations,
@@ -69,7 +70,7 @@ class Pregnancy(Component):
             required_resources=[
                 COLUMNS.PREGNANCY_OUTCOME,
                 COLUMNS.PARTIAL_TERM_PREGNANCY_DURATION,
-                self.gestational_age_pipeline,
+                COLUMNS.GESTATIONAL_AGE_EXPOSURE,
             ],
         )
 
@@ -176,7 +177,7 @@ class Pregnancy(Component):
         ]
         partial_ga = pop.loc[partial_term_idx, COLUMNS.PARTIAL_TERM_PREGNANCY_DURATION]
         non_partial_idx = index.difference(partial_term_idx)
-        non_partial_ga = self.gestational_age_pipeline(non_partial_idx)
+        non_partial_ga = pop.loc[non_partial_idx, COLUMNS.GESTATIONAL_AGE_EXPOSURE]
 
         gestational_ages = pd.concat([partial_ga, non_partial_ga]).sort_index()
         durations = pd.to_timedelta(7 * gestational_ages, unit="days")

--- a/src/vivarium_gates_mncnh/constants/data_keys.py
+++ b/src/vivarium_gates_mncnh/constants/data_keys.py
@@ -53,6 +53,7 @@ PREGNANCY = __Pregnancy()
 class __LowBirthWeightShortGestation(NamedTuple):
     # Keys that will be loaded into the artifact. must have a colon type declaration
     BIRTH_EXPOSURE: str = "risk_factor.low_birth_weight_and_short_gestation.birth_exposure"
+    EXPOSURE: str = "risk_factor.low_birth_weight_and_short_gestation.exposure"
     DISTRIBUTION: str = "risk_factor.low_birth_weight_and_short_gestation.distribution"
     CATEGORIES: str = "risk_factor.low_birth_weight_and_short_gestation.categories"
     RELATIVE_RISK: str = "risk_factor.low_birth_weight_and_short_gestation.relative_risk"

--- a/src/vivarium_gates_mncnh/data/extra_gbd.py
+++ b/src/vivarium_gates_mncnh/data/extra_gbd.py
@@ -26,7 +26,7 @@ def get_maternal_disorder_yld_rate(key: str, location: str) -> pd.DataFrame:
 
 
 @vi_utils.cache
-def load_lbwsg_exposure(location: str, key: str):
+def load_lbwsg_exposure(location: str) -> pd.DataFrame:
     entity = utilities.get_entity(data_keys.LBWSG.BIRTH_EXPOSURE)
     location_id = utility_data.get_location_id(location)
     data = vi_utils.get_draws(

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -532,7 +532,7 @@ def load_lbwsg_birth_exposure(
     birth_exposure = birth_exposure.loc[
         birth_exposure["parameter"] != extra_residual_category
     ]
-    idx_cols = ["location_id", "year_id", "sex_id", "parameter"]
+    idx_cols = ["location_id", "age_group_id", "year_id", "sex_id", "parameter"]
     birth_exposure = birth_exposure.set_index(idx_cols)[vi_globals.DRAW_COLUMNS]
 
     # Sometimes there are data values on the order of 10e-300 that cause
@@ -540,8 +540,12 @@ def load_lbwsg_birth_exposure(
     birth_exposure = birth_exposure.clip(lower=vi_globals.MINIMUM_EXPOSURE_VALUE)
 
     # normalize so all categories sum to 1
-    total_exposure = birth_exposure.groupby(["location_id", "sex_id"]).transform("sum")
-    birth_exposure = (birth_exposure / total_exposure).reset_index()
+    total_exposure = birth_exposure.groupby(
+        ["location_id", "age_group_id", "sex_id"]
+    ).transform("sum")
+    birth_exposure = (
+        (birth_exposure / total_exposure).reset_index().drop(columns=["age_group_id"])
+    )
     birth_exposure = reshape_to_vivarium_format(birth_exposure, location)
     return birth_exposure
 

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -532,7 +532,7 @@ def load_lbwsg_birth_exposure(
     birth_exposure = birth_exposure.loc[
         birth_exposure["parameter"] != extra_residual_category
     ]
-    idx_cols = ["location_id", "age_group_id", "year_id", "sex_id", "parameter"]
+    idx_cols = ["age_group_id", "year_id", "sex_id", "parameter"]
     birth_exposure = birth_exposure.set_index(idx_cols)[vi_globals.DRAW_COLUMNS]
 
     # Sometimes there are data values on the order of 10e-300 that cause
@@ -540,9 +540,7 @@ def load_lbwsg_birth_exposure(
     birth_exposure = birth_exposure.clip(lower=vi_globals.MINIMUM_EXPOSURE_VALUE)
 
     # normalize so all categories sum to 1
-    total_exposure = birth_exposure.groupby(
-        ["location_id", "age_group_id", "sex_id"]
-    ).transform("sum")
+    total_exposure = birth_exposure.groupby(["age_group_id", "sex_id"]).transform("sum")
     birth_exposure = (birth_exposure / total_exposure).reset_index()
     birth_exposure = reshape_to_vivarium_format(birth_exposure, location)
     return birth_exposure

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -523,8 +523,10 @@ def load_lbwsg_birth_exposure(
     if key != data_keys.LBWSG.BIRTH_EXPOSURE:
         raise ValueError(f"Unrecognized key {key}")
 
-    entity = utilities.get_entity(key)
-    birth_exposure = load_standard_data(key, location, years)
+    # THis is using the old key due to VPH and VI update
+    exposure_key = "risk_factor.low_birth_weight_and_short_gestation.exposure"
+    entity = utilities.get_entity(exposure_key)
+    birth_exposure = extra_gbd.load_lbwsg_exposure(location)
     # This category was a mistake in GBD 2019, so drop.
     extra_residual_category = vi_globals.EXTRA_RESIDUAL_CATEGORY[entity.name]
     birth_exposure = birth_exposure.loc[
@@ -561,7 +563,7 @@ def load_lbwsg_exposure(
     exposure = (
         (exposure / total_exposure)
         .reset_index()
-        .set_index(ARTIFACT_INDEX_COLUMNS)
+        .set_index(metadata.ARTIFACT_INDEX_COLUMNS)
         .sort_index()
     )
     return exposure

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -67,7 +67,8 @@ def get_data(
         data_keys.PREGNANCY.RAW_INCIDENCE_RATE_ECTOPIC: load_raw_incidence_data,
         data_keys.LBWSG.DISTRIBUTION: load_metadata,
         data_keys.LBWSG.CATEGORIES: load_metadata,
-        data_keys.LBWSG.BIRTH_EXPOSURE: load_lbwsg_exposure,
+        data_keys.LBWSG.BIRTH_EXPOSURE: load_lbwsg_birth_exposure,
+        data_keys.LBWSG.EXPOSURE: load_lbwsg_exposure,
         data_keys.LBWSG.RELATIVE_RISK: load_lbwsg_rr,
         data_keys.LBWSG.RELATIVE_RISK_INTERPOLATOR: load_lbwsg_interpolated_rr,
         data_keys.LBWSG.PAF: load_paf_data,
@@ -515,41 +516,54 @@ def load_no_cpap_paf(
     return paf_no_cpap
 
 
-def load_lbwsg_exposure(
+def load_lbwsg_birth_exposure(
     key: str, location: str, years: Optional[Union[int, str, List[int]]] = None
 ) -> pd.DataFrame:
 
     if key != data_keys.LBWSG.BIRTH_EXPOSURE:
         raise ValueError(f"Unrecognized key {key}")
 
-    # THis is using the old key due to VPH and VI update
-    exposure_key = "risk_factor.low_birth_weight_and_short_gestation.exposure"
-    # Get exposure for all age groups except birth age group
-    all_age_exposure = load_standard_data(exposure_key, location, years)
-
-    entity = utilities.get_entity(exposure_key)
-    birth_exposure = extra_gbd.load_lbwsg_exposure(location, exposure_key)
+    entity = utilities.get_entity(key)
+    birth_exposure = load_standard_data(key, location, years)
     # This category was a mistake in GBD 2019, so drop.
     extra_residual_category = vi_globals.EXTRA_RESIDUAL_CATEGORY[entity.name]
     birth_exposure = birth_exposure.loc[
         birth_exposure["parameter"] != extra_residual_category
     ]
-    birth_exposure = birth_exposure.set_index(
-        ["location_id", "year_id", "sex_id", "parameter"]
-    )[vi_globals.DRAW_COLUMNS]
+    idx_cols = ["location_id", "age_group_id", "year_id", "sex_id", "parameter"]
+    birth_exposure = birth_exposure.set_index(idx_cols)[vi_globals.DRAW_COLUMNS]
+
     # Sometimes there are data values on the order of 10e-300 that cause
     # floating point headaches, so clip everything to reasonable values
     birth_exposure = birth_exposure.clip(lower=vi_globals.MINIMUM_EXPOSURE_VALUE)
-    birth_exposure = reshape_to_vivarium_format(birth_exposure, location).reset_index()
-    birth_exposure["age_start"] = (0 - 7) / 365.0
-    birth_exposure["age_end"] = 0.0
-    idx_cols = ["sex", "age_start", "age_end", "year_start", "year_end", "parameter"]
-    exposure = pd.concat([all_age_exposure.reset_index(), birth_exposure])
-    exposure = exposure.set_index(idx_cols)[vi_globals.DRAW_COLUMNS]
+
+    # normalize so all categories sum to 1
+    total_exposure = birth_exposure.groupby(
+        ["location_id", "age_group_id", "sex_id"]
+    ).transform("sum")
+    birth_exposure = (birth_exposure / total_exposure).reset_index()
+    birth_exposure = reshape_to_vivarium_format(birth_exposure, location)
+    return birth_exposure
+
+
+def load_lbwsg_exposure(
+    key: str, location: str, years: Optional[Union[int, str, List[int]]] = None
+) -> pd.DataFrame:
+
+    # Get exposure for all age groups except birth age group
+    exposure = load_standard_data(key, location, years)
+    # Sometimes there are data values on the order of 10e-300 that cause
+    # floating point headaches, so clip everything to reasonable values
+    exposure = exposure.clip(lower=vi_globals.MINIMUM_EXPOSURE_VALUE)
 
     # normalize so all categories sum to 1
     total_exposure = exposure.groupby(["age_start", "age_end", "sex"]).transform("sum")
-    exposure = (exposure / total_exposure).reset_index().set_index(idx_cols).sort_index()
+    exposure = (
+        (exposure / total_exposure)
+        .reset_index()
+        .set_index(ARTIFACT_INDEX_COLUMNS)
+        .sort_index()
+    )
     return exposure
 
 

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -575,9 +575,7 @@ def load_preterm_prevalence(
     key: str, location: str, years: Optional[Union[int, str, List[int]]] = None
 ) -> pd.DataFrame:
     # TODO: implement
-    exposure = get_data(data_keys.LBWSG.BIRTH_EXPOSURE, location, years).reset_index()
-    # Remove birth age group
-    exposure = exposure.loc[exposure["age_end"] > 0.0]
+    exposure = get_data(data_keys.LBWSG.EXPOSURE, location, years).reset_index()
     categories = get_data(data_keys.LBWSG.CATEGORIES, location, years)
     # Get preterm categories
     preterm_cats = []

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -532,7 +532,7 @@ def load_lbwsg_birth_exposure(
     birth_exposure = birth_exposure.loc[
         birth_exposure["parameter"] != extra_residual_category
     ]
-    idx_cols = ["age_group_id", "year_id", "sex_id", "parameter"]
+    idx_cols = ["location_id", "year_id", "sex_id", "parameter"]
     birth_exposure = birth_exposure.set_index(idx_cols)[vi_globals.DRAW_COLUMNS]
 
     # Sometimes there are data values on the order of 10e-300 that cause
@@ -540,7 +540,7 @@ def load_lbwsg_birth_exposure(
     birth_exposure = birth_exposure.clip(lower=vi_globals.MINIMUM_EXPOSURE_VALUE)
 
     # normalize so all categories sum to 1
-    total_exposure = birth_exposure.groupby(["age_group_id", "sex_id"]).transform("sum")
+    total_exposure = birth_exposure.groupby(["location_id", "sex_id"]).transform("sum")
     birth_exposure = (birth_exposure / total_exposure).reset_index()
     birth_exposure = reshape_to_vivarium_format(birth_exposure, location)
     return birth_exposure

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -547,7 +547,8 @@ def load_lbwsg_birth_exposure(
         (birth_exposure / total_exposure).reset_index().drop(columns=["age_group_id"])
     )
     birth_exposure = reshape_to_vivarium_format(birth_exposure, location)
-    return birth_exposure
+
+    return utilities.rename_child_data_index_names(birth_exposure)
 
 
 def load_lbwsg_exposure(
@@ -565,7 +566,7 @@ def load_lbwsg_exposure(
     exposure = (
         (exposure / total_exposure)
         .reset_index()
-        .set_index(metadata.ARTIFACT_INDEX_COLUMNS)
+        .set_index(metadata.ARTIFACT_INDEX_COLUMNS + ["parameter"])
         .sort_index()
     )
     return exposure

--- a/src/vivarium_gates_mncnh/data/utilities.py
+++ b/src/vivarium_gates_mncnh/data/utilities.py
@@ -92,3 +92,4 @@ def rename_child_data_index_names(data: pd.DataFrame) -> pd.DataFrame:
             data.index.rename({column: "sex_of_child"}, inplace=True)
         else:
             data.index.rename(index={column: f"child_{column}"}, inplace=True)
+    return data

--- a/src/vivarium_gates_mncnh/data/utilities.py
+++ b/src/vivarium_gates_mncnh/data/utilities.py
@@ -89,6 +89,6 @@ def rename_child_data_index_names(data: pd.DataFrame) -> pd.DataFrame:
         if column not in data.index.names:
             continue
         if column == "sex":
-            data.insex.rename({column: "sex_of_child"}, inplace=True)
+            data.index.rename({column: "sex_of_child"}, inplace=True)
         else:
-            data.rename(index={column: f"child_{column}"}, inplace=True)
+            data.index.rename(index={column: f"child_{column}"}, inplace=True)

--- a/src/vivarium_gates_mncnh/data/utilities.py
+++ b/src/vivarium_gates_mncnh/data/utilities.py
@@ -81,3 +81,14 @@ def set_non_neonnatal_values(data: pd.DataFrame, value: float) -> pd.DataFrame:
     data = data.reset_index()
     data.loc[data["age_start"] > 7 / 365.0, ARTIFACT_COLUMNS] = value
     return data.set_index(ARTIFACT_INDEX_COLUMNS)
+
+
+def rename_child_data_index_names(data: pd.DataFrame) -> pd.DataFrame:
+    # Renames index names in artifact data for child age and sex
+    for column in ["sex", "age_start", "age_end"]:
+        if column not in data.index.names:
+            continue
+        if column == "sex":
+            data.insex.rename({column: "sex_of_child"}, inplace=True)
+        else:
+            data.rename(index={column: f"child_{column}"}, inplace=True)

--- a/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
@@ -43,7 +43,7 @@ components:
 configuration:
     input_data:
         input_draw_number: 0
-        artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/antibiotics/ethiopia.hdf"
+        artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/birth_exposure/ethiopia.hdf"
     interpolation:
         order: 0
         extrapolate: True

--- a/tests/test_lbwsg.py
+++ b/tests/test_lbwsg.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from vivarium import Artifact, InteractiveContext
+from vivarium_testing_utils import FuzzyChecker
+
+from vivarium_gates_mncnh.constants.data_keys import LBWSG
+from vivarium_gates_mncnh.constants.data_values import (
+    COLUMNS,
+    PIPELINES,
+    SIMULATION_EVENT_NAMES,
+)
+
+from .utilities import get_interactive_context_state
+
+
+@pytest.fixture(scope="module")
+def birth_state(
+    model_spec_path: Path, sim_state_step_mapper: dict[str, int]
+) -> InteractiveContext:
+    sim = InteractiveContext(model_spec_path)
+    return get_interactive_context_state(
+        sim, sim_state_step_mapper, SIMULATION_EVENT_NAMES.PREGNANCY
+    )
+
+
+@pytest.fixture(scope="module")
+def population(birth_state: InteractiveContext) -> pd.DataFrame:
+    return birth_state.get_population()
+
+
+def test_birth_exposure_coverage(
+    birth_state: InteractiveContext,
+    population: pd.DataFrame,
+    artifact: Artifact,
+    fuzzy_checker: FuzzyChecker,
+) -> None:
+    """Tests that the birth exposure coverage is correct"""
+    draw = (
+        f"draw_{birth_state.model_specification.configuration.input_data.input_draw_number}"
+    )
+    birth_exposure = artifact.load(LBWSG.BIRTH_EXPOSURE)[draw].reset_index()
+    sim_exposure = population[
+        [
+            COLUMNS.SEX_OF_CHILD,
+            COLUMNS.GESTATIONAL_AGE_EXPOSURE,
+            COLUMNS.BIRTH_WEIGHT_EXPOSURE,
+        ]
+    ].copy()
+    category_intervals = birth_state.get_component(
+        "risk_factor.low_birth_weight_and_short_gestation"
+    ).exposure_distribution.category_intervals
+
+    def map_to_category(value: float, category_dict: dict[str, pd.Interval]) -> list[str]:
+        categories = []
+        for key, interval in category_dict.items():
+            if value in interval:
+                categories.append(key)
+        return categories
+
+    # Map 'gestational_age' to its categories
+    sim_exposure["gestational_age_category"] = sim_exposure["gestational_age_exposure"].apply(
+        lambda x: map_to_category(x, category_intervals["gestational_age"])
+    )
+    # Map 'birth_weight' to its categories
+    sim_exposure["birth_weight_category"] = sim_exposure["birth_weight_exposure"].apply(
+        lambda x: map_to_category(x, category_intervals["birth_weight"])
+    )
+    # Get common category
+    sim_exposure["exposure_categories"] = sim_exposure.apply(
+        lambda row: set(row["gestational_age_category"]) & set(row["birth_weight_category"]),
+        axis=1,
+    )
+
+    # Get single category from set returned above but throw error if simulant is in two categories
+    def extract_set_value(s: set) -> str:
+        if len(s) == 1:
+            return s.pop()
+        else:
+            raise ValueError("Simulant is in multiple LBWSG categories")
+
+    sim_exposure["category"] = sim_exposure["exposure_categories"].apply(extract_set_value)
+
+    # Check each combination of sex and category
+    for sex in ["Female", "Male"]:
+        sex_subset = sim_exposure.loc[sim_exposure[COLUMNS.SEX_OF_CHILD] == sex]
+        sex_exposure = birth_exposure.loc[birth_exposure[COLUMNS.SEX_OF_CHILD] == sex]
+        for category in sex_exposure.parameter:
+            expected_exposure = sex_exposure.loc[sex_exposure["parameter"] == category][
+                draw
+            ].iloc[0]
+            fuzzy_checker.fuzzy_assert_proportion(
+                len(sex_subset.loc[sex_subset["category"] == category]),
+                len(sex_subset),
+                expected_exposure,
+                name=f"{sex}_{category}_exposure_proportion",
+            )

--- a/tests/test_pregnancy.py
+++ b/tests/test_pregnancy.py
@@ -57,9 +57,7 @@ def test_pregnancy_duration_pipeline(
     ]
     partial_ga = population.loc[partial_term_idx, COLUMNS.PARTIAL_TERM_PREGNANCY_DURATION]
     non_partial_idx = population.index.difference(partial_term_idx)
-    non_partial_ga = pregnancy_state.get_value(PIPELINES.GESTATIONAL_AGE_EXPOSURE)(
-        non_partial_idx
-    )
+    non_partial_ga = population.loc[non_partial_idx, COLUMNS.GESTATIONAL_AGE_EXPOSURE]
     gestational_age = pd.concat([partial_ga, non_partial_ga]).sort_index()
     unit_converted_ga = pd.to_timedelta(7 * gestational_age, unit="days")
     pregnancy_duration = pregnancy_state.get_value(PIPELINES.PREGNANCY_DURATION)(

--- a/tests/test_pregnancy.py
+++ b/tests/test_pregnancy.py
@@ -2,8 +2,7 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
-from vivarium import Artifact, InteractiveContext
-from vivarium_testing_utils import FuzzyChecker
+from vivarium import InteractiveContext
 
 from vivarium_gates_mncnh.constants.data_values import (
     COLUMNS,
@@ -58,7 +57,9 @@ def test_pregnancy_duration_pipeline(
     ]
     partial_ga = population.loc[partial_term_idx, COLUMNS.PARTIAL_TERM_PREGNANCY_DURATION]
     non_partial_idx = population.index.difference(partial_term_idx)
-    non_partial_ga = population.loc[non_partial_idx, COLUMNS.GESTATIONAL_AGE_EXPOSURE]
+    non_partial_ga = pregnancy_state.get_value(PIPELINES.GESTATIONAL_AGE_EXPOSURE)(
+        non_partial_idx
+    )
     gestational_age = pd.concat([partial_ga, non_partial_ga]).sort_index()
     unit_converted_ga = pd.to_timedelta(7 * gestational_age, unit="days")
     pregnancy_duration = pregnancy_state.get_value(PIPELINES.PREGNANCY_DURATION)(


### PR DESCRIPTION
## Albrja/mic 5972/lbwsg birth exposure

### Updates LBWSG to use birth exposure data without age group
- *Category*: Bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5972
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
-updates data backing LBWSG components
-birth exposure pipeliens from LBWSG no longer required child age
-adds exposure test

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

