### PR TITLE
Albrja/mic-6067/probiotic-preterm-access

### DIFF
--- a/src/vivarium_gates_mncnh/components/intrapartum.py
+++ b/src/vivarium_gates_mncnh/components/intrapartum.py
@@ -7,7 +7,12 @@ from vivarium.framework.event import Event
 from vivarium.framework.lookup import LookupTable
 from vivarium.framework.population import SimulantData
 
-from vivarium_gates_mncnh.constants.data_values import COLUMNS, DELIVERY_FACILITY_TYPES
+from vivarium_gates_mncnh.constants.data_values import (
+    COLUMNS,
+    DELIVERY_FACILITY_TYPES,
+    NEONATAL_INTERVENTIONS,
+)
+from vivarium_gates_mncnh.constants.metadata import PRETERM_AGE_CUTOFF
 from vivarium_gates_mncnh.constants.scenarios import INTERVENTION_SCENARIOS
 
 
@@ -36,7 +41,7 @@ class NeonatalInterventionAccess(Component):
 
     @property
     def columns_required(self) -> list[str]:
-        return [COLUMNS.DELIVERY_FACILITY_TYPE]
+        return [COLUMNS.DELIVERY_FACILITY_TYPE, COLUMNS.GESTATIONAL_AGE_EXPOSURE]
 
     def __init__(self, intervention: str) -> None:
         super().__init__()
@@ -64,6 +69,9 @@ class NeonatalInterventionAccess(Component):
             return
 
         pop = self.population_view.get(event.index)
+        # If intervention is probiotics, filter for preterm births
+        if self.intervention == NEONATAL_INTERVENTIONS.PROBIOTICS:
+            pop = pop.loc[pop[COLUMNS.GESTATIONAL_AGE_EXPOSURE] < PRETERM_AGE_CUTOFF]
 
         for (
             facility_type,

--- a/src/vivarium_gates_mncnh/components/neonatal_causes.py
+++ b/src/vivarium_gates_mncnh/components/neonatal_causes.py
@@ -13,6 +13,7 @@ from vivarium_gates_mncnh.constants.data_values import (
     PIPELINES,
     PRETERM_DEATHS_DUE_TO_RDS_PROBABILITY,
 )
+from vivarium_gates_mncnh.constants.metadata import PRETERM_AGE_CUTOFF
 
 
 class NeonatalCause(Component):
@@ -114,7 +115,7 @@ class PretermBirth(NeonatalCause):
 
     def get_normalized_csmr(self, index: pd.Index) -> pd.Series:
         pop = self.population_view.get(index)
-        ga_greater_than_37 = pop[COLUMNS.GESTATIONAL_AGE_EXPOSURE] >= 37
+        ga_greater_than_37 = pop[COLUMNS.GESTATIONAL_AGE_EXPOSURE] >= PRETERM_AGE_CUTOFF
 
         # CSMR = (1 - PAF) * RR * (CSMR / PRETERM_PREVALENCE)
         # NOTE: This isn't technically a traditional PAF but it is the

--- a/src/vivarium_gates_mncnh/constants/data_values.py
+++ b/src/vivarium_gates_mncnh/constants/data_values.py
@@ -340,3 +340,12 @@ ANTIBIOTIC_RELATIVE_RISK_DISTRIBUTION = get_norm(1.39, 0.08**2)
 
 PROBIOTICS_BASELINE_COVERAGE_PROABILITY = 0.0
 PROBIOTICS_RELATIVE_RISK_DISTRIBUTION = get_norm(1.67, 0.08**2)
+
+
+class __NeonatalInterventions(NamedTuple):
+    CPAP: str = "cpap"
+    ANTIBIOTICS: str = "antibiotics"
+    PROBIOTICS: str = "probiotics"
+
+
+NEONATAL_INTERVENTIONS = __NeonatalInterventions()

--- a/src/vivarium_gates_mncnh/constants/metadata.py
+++ b/src/vivarium_gates_mncnh/constants/metadata.py
@@ -48,3 +48,6 @@ class __Scenarios(NamedTuple):
 
 
 SCENARIOS = __Scenarios()
+
+
+PRETERM_AGE_CUTOFF = 37.0  # weeks

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -599,7 +599,7 @@ def load_preterm_prevalence(
     preterm_cats = []
     for cat, description in categories.items():
         i = utilities.parse_short_gestation_description(description)
-        if i.right < 37:
+        if i.right < metadata.PRETERM_AGE_CUTOFF:
             preterm_cats.append(cat)
 
     # Subset exposure to preterm categories

--- a/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
@@ -46,8 +46,7 @@ components:
 configuration:
     input_data:
         input_draw_number: 0
-        artifact_path: /home/albrja/scratch/artifacts/ethiopia.hdf
-        # artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/paf2.0/ethiopia.hdf"
+        artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/paf2.0/ethiopia.hdf"
     interpolation:
         order: 0
         extrapolate: True

--- a/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
@@ -46,7 +46,8 @@ components:
 configuration:
     input_data:
         input_draw_number: 0
-        artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/paf2.0/ethiopia.hdf"
+        artifact_path: /home/albrja/scratch/artifacts/ethiopia.hdf
+        # artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/paf2.0/ethiopia.hdf"
     interpolation:
         order: 0
         extrapolate: True
@@ -54,11 +55,12 @@ configuration:
         map_size: 1_000_000
         key_columns: ['entrance_time', 'age']
         random_seed: 0
+        rate_conversion_type: 'exponential'
     time:
         start:
             year: 2025
             month: 1
-            day: 1
+            day: 1 
         simulation_events: 
             - 'pregnancy'
             - 'delivery_facility'

--- a/tests/test_intrapartum.py
+++ b/tests/test_intrapartum.py
@@ -11,6 +11,7 @@ from vivarium_gates_mncnh.constants.data_values import (
     DELIVERY_FACILITY_TYPES,
     SIMULATION_EVENT_NAMES,
 )
+from vivarium_gates_mncnh.constants.metadata import PRETERM_AGE_CUTOFF
 
 from .utilities import get_interactive_context_state
 
@@ -21,7 +22,7 @@ def intrapartum_state(
 ) -> InteractiveContext:
     sim = InteractiveContext(model_spec_path)
     return get_interactive_context_state(
-        sim, sim_state_step_mapper, SIMULATION_EVENT_NAMES.ANTIBIOTICS_ACCESS
+        sim, sim_state_step_mapper, SIMULATION_EVENT_NAMES.PROBIOTICS_ACCESS
     )
 
 
@@ -116,3 +117,11 @@ def test_intervention_availability(
         facility_access_probability,
         name=f"{intervention}_availability_{facility_type}_proportion",
     )
+
+
+def test_probiotics_access(population: pd.DataFrame) -> None:
+    # Probiotics is only available for preterm births
+    not_preterm_idx = population.index[
+        population[COLUMNS.GESTATIONAL_AGE_EXPOSURE] >= PRETERM_AGE_CUTOFF
+    ]
+    assert (population.loc[not_preterm_idx, COLUMNS.PROBIOTICS_AVAILABLE] == False).all()


### PR DESCRIPTION
## Albrja/mic-6067/probiotic-preterm-access

### Update probiotic intervention access to only give to preterm births
- *Category*: Feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6067
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/intervention_models/neonatal/probiotics_intervention.html#vivarium-modeling-strategy

### Changes and notes
-only allow probiotic access to preterm births

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

