### PR TITLE
Albrja/mic 6146/model 8.1

### DIFF
--- a/src/vivarium_gates_mncnh/data/lbwsg_paf.yaml
+++ b/src/vivarium_gates_mncnh/data/lbwsg_paf.yaml
@@ -11,7 +11,7 @@ components:
 configuration:
     input_data:
         input_draw_number: 0
-        artifact_path: '/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/probiotics/ethiopia.hdf'
+        artifact_path: '/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/model8.1/ethiopia.hdf'
     interpolation:
         order: 0
         extrapolate: True

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -343,6 +343,8 @@ def load_lbwsg_rr(
     data = load_standard_data(key, location, years)
     data = data.query("year_start == 2021").droplevel(["affected_entity", "affected_measure"])
     data = data[~data.index.duplicated()]
+    cap_mask = df > 100.0
+    df[cap_mask] = 100.0
     return data
 
 

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -343,8 +343,8 @@ def load_lbwsg_rr(
     data = load_standard_data(key, location, years)
     data = data.query("year_start == 2021").droplevel(["affected_entity", "affected_measure"])
     data = data[~data.index.duplicated()]
-    cap_mask = df > 100.0
-    df[cap_mask] = 100.0
+    cap_mask = data > 100.0
+    data[cap_mask] = 100.0
     return data
 
 

--- a/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
@@ -49,7 +49,7 @@ components:
 configuration:
     input_data:
         input_draw_number: 0
-        artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/model8.0/ethiopia.hdf"
+        artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/model8.1/ethiopia.hdf"
     interpolation:
         order: 0
         extrapolate: True


### PR DESCRIPTION
## Albrja/mic 6146/model 8.1

### Cap LBWSG relative risks at 100 and rerun model pipeline.
- *Category*: Implementation
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6146
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/causes/neonatal/index.html#id4

### Changes and notes
-cap LBWSG relative risks at 100
-rerun PAF simulation to recalculate PAFs
-run model 8.1 

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

