### PR TITLE
model 12.1 fix preterm prevalence

### DIFF
--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -639,7 +639,7 @@ def load_preterm_prevalence(
     preterm_cats = []
     for cat, description in categories.items():
         i = utilities.parse_short_gestation_description(description)
-        if i.right < metadata.PRETERM_AGE_CUTOFF:
+        if i.right <= metadata.PRETERM_AGE_CUTOFF:
             preterm_cats.append(cat)
 
     # Subset exposure to preterm categories


### PR DESCRIPTION
## model 12.1 fix preterm prevalence

### Description
- *Category*: artifact bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6221

### Changes and notes
Use less than OR EQUAL TO rather than less than. This way we will include the LBWSG categories whose right interval for gestational age is equal to the cutoff for a preterm birth (37 weeks), who were previously being excluded when calculating preterm prevalence.

### Verification and Testing
Remade artifact and checked that there were changes.