### PR TITLE
fix RR start and intervals and use location-specific PAFs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
         "gbd_mapping>=4.0.0",
         "layered_config_tree",
         "vivarium>=3.4.7",
-        "vivarium_public_health>=4.2.5,<4.3.0",
+        "vivarium_public_health>=4.2.5",
         "click",
         "jinja2",
         "loguru",

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
         "gbd_mapping>=4.0.0",
         "layered_config_tree",
         "vivarium>=3.4.7",
-        "vivarium_public_health>=4.3.0",
+        "vivarium_public_health>=4.2.5,<4.3.0",
         "click",
         "jinja2",
         "loguru",

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
         "gbd_mapping>=4.0.0",
         "layered_config_tree",
         "vivarium>=3.4.7",
-        "vivarium_public_health>=4.2.5",
+        "vivarium_public_health>=4.3.0",
         "click",
         "jinja2",
         "loguru",

--- a/src/vivarium_gates_mncnh/components/__init__.py
+++ b/src/vivarium_gates_mncnh/components/__init__.py
@@ -1,5 +1,6 @@
 from vivarium_gates_mncnh.components.antenatal_care import AntenatalCare
 from vivarium_gates_mncnh.components.delivery_facility import DeliveryFacility
+from vivarium_gates_mncnh.components.hemoglobin import HemoglobinRiskEffect
 from vivarium_gates_mncnh.components.intervention import InterventionRiskEffect
 from vivarium_gates_mncnh.components.intrapartum import InterventionAccess
 from vivarium_gates_mncnh.components.lbwsg import (

--- a/src/vivarium_gates_mncnh/components/hemoglobin.py
+++ b/src/vivarium_gates_mncnh/components/hemoglobin.py
@@ -1,0 +1,114 @@
+import numpy as np
+import pandas as pd
+import scipy
+from vivarium.framework.engine import Builder
+from vivarium_public_health.risks.distributions import MissingDataError
+from vivarium_public_health.risks.effect import NonLogLinearRiskEffect
+
+
+class HemoglobinRiskEffect(NonLogLinearRiskEffect):
+    """Make some small modifications to the NonLogLinearRiskEffect class to handle hemoglobin data.
+    These are 1) define the RR for the minimum exposure to be the maximum rather than minimum value
+    (higher hemoglobin is protective at this level of exposure) and 2) allow RRs to be below 1."""
+
+    def build_all_lookup_tables(self, builder: Builder) -> None:
+        rr_data = self.load_relative_risk(builder)
+        self.validate_rr_data(rr_data)
+
+        def define_rr_intervals(df: pd.DataFrame) -> pd.DataFrame:
+            # create new row for right-most exposure bin (RR is same as max RR)
+            max_exposure_row = df.tail(1).copy()
+            max_exposure_row["parameter"] = np.inf
+            rr_data = pd.concat([df, max_exposure_row]).reset_index()
+
+            rr_data["left_exposure"] = [0] + rr_data["parameter"][:-1].tolist()
+            # use max rather than min value
+            rr_data["left_rr"] = [rr_data["value"].max()] + rr_data["value"][:-1].tolist()
+            rr_data["right_exposure"] = rr_data["parameter"]
+            rr_data["right_rr"] = rr_data["value"]
+
+            return rr_data[
+                ["parameter", "left_exposure", "left_rr", "right_exposure", "right_rr"]
+            ]
+
+        # define exposure and rr interval columns
+        demographic_cols = [
+            col for col in rr_data.columns if col != "parameter" and col != "value"
+        ]
+        rr_data = (
+            rr_data.groupby(demographic_cols)
+            .apply(define_rr_intervals)
+            .reset_index(level=-1, drop=True)
+            .reset_index()
+        )
+        rr_data = rr_data.drop("parameter", axis=1)
+        rr_data[f"{self.risk.name}_exposure_start"] = rr_data["left_exposure"]
+        rr_data[f"{self.risk.name}_exposure_end"] = rr_data["right_exposure"]
+        # build lookup table
+        rr_value_cols = ["left_exposure", "left_rr", "right_exposure", "right_rr"]
+        self.lookup_tables["relative_risk"] = self.build_lookup_table(
+            builder, rr_data, rr_value_cols
+        )
+
+        paf_data = self.get_filtered_data(
+            builder, self.configuration.data_sources.population_attributable_fraction
+        )
+        self.lookup_tables["population_attributable_fraction"] = self.build_lookup_table(
+            builder, paf_data
+        )
+
+    def load_relative_risk(
+        self,
+        builder: Builder,
+        configuration=None,
+    ) -> str | float | pd.DataFrame:
+        if configuration is None:
+            configuration = self.configuration
+
+        # get TMREL
+        tmred = builder.data.load(f"{self.risk}.tmred")
+        if tmred["distribution"] == "uniform":
+            draw = builder.configuration.input_data.input_draw_number
+            rng = np.random.default_rng(builder.randomness.get_seed(self.name + str(draw)))
+            self.tmrel = rng.uniform(tmred["min"], tmred["max"])
+        elif tmred["distribution"] == "draws":  # currently only for iron deficiency
+            raise MissingDataError(
+                f"This data has draw-level TMRELs. You will need to contact the research team that models {self.risk.name} to get this data."
+            )
+        else:
+            raise MissingDataError(f"No TMRED found in gbd_mapping for risk {self.risk.name}")
+
+        # calculate RR at TMREL
+        rr_source = configuration.data_sources.relative_risk
+        original_rrs = self.get_filtered_data(builder, rr_source)
+
+        self.validate_rr_data(original_rrs)
+
+        demographic_cols = [
+            col for col in original_rrs.columns if col != "parameter" and col != "value"
+        ]
+
+        def get_rr_at_tmrel(rr_data: pd.DataFrame) -> float:
+            interpolated_rr_function = scipy.interpolate.interp1d(
+                rr_data["parameter"],
+                rr_data["value"],
+                kind="linear",
+                bounds_error=False,
+                fill_value=(
+                    rr_data["value"].min(),
+                    rr_data["value"].max(),
+                ),
+            )
+            rr_at_tmrel = interpolated_rr_function(self.tmrel).item()
+            return rr_at_tmrel
+
+        rrs_at_tmrel = (
+            original_rrs.groupby(demographic_cols)
+            .apply(get_rr_at_tmrel)
+            .rename("rr_at_tmrel")
+        )
+        rr_data = original_rrs.merge(rrs_at_tmrel.reset_index())
+        rr_data["value"] = rr_data["value"] / rr_data["rr_at_tmrel"]
+        rr_data = rr_data.drop("rr_at_tmrel", axis=1)
+
+        return rr_data

--- a/src/vivarium_gates_mncnh/components/hemoglobin.py
+++ b/src/vivarium_gates_mncnh/components/hemoglobin.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import scipy
 from vivarium.framework.engine import Builder
-from vivarium_public_health.risks.distributions import MissingDataError
+from vivarium_public_health.exposure.distributions import MissingDataError
 from vivarium_public_health.risks.effect import NonLogLinearRiskEffect
 
 

--- a/src/vivarium_gates_mncnh/components/hemoglobin.py
+++ b/src/vivarium_gates_mncnh/components/hemoglobin.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import scipy
 from vivarium.framework.engine import Builder
-from vivarium_public_health.exposure.distributions import MissingDataError
+from vivarium_public_health.risks.distributions import MissingDataError
 from vivarium_public_health.risks.effect import NonLogLinearRiskEffect
 
 

--- a/src/vivarium_gates_mncnh/data/extra_gbd.py
+++ b/src/vivarium_gates_mncnh/data/extra_gbd.py
@@ -109,7 +109,7 @@ def get_hemoglobin_rr_data(key: str, location: str) -> pd.DataFrame:
         gbd_id=376,
         source=gbd_constants.SOURCES.RR,
         sex_id=gbd_constants.SEX.FEMALE,
-        location_id=1,
+        location_id=1,  # global data
         year_id=2022,
     )
     return data
@@ -117,6 +117,7 @@ def get_hemoglobin_rr_data(key: str, location: str) -> pd.DataFrame:
 
 @vi_utils.cache
 def get_hemoglobin_paf_data(key: str, location: str) -> pd.DataFrame:
+    location_id = utility_data.get_location_id(location)
     data = vi_utils.get_draws(
         release_id=33,
         version_id=393,
@@ -124,7 +125,7 @@ def get_hemoglobin_paf_data(key: str, location: str) -> pd.DataFrame:
         gbd_id=376,
         source=gbd_constants.SOURCES.BURDENATOR,
         sex_id=gbd_constants.SEX.FEMALE,
-        location_id=1,
+        location_id=location_id,  # location-specific data
         year_id=2023,
         metric_id=vi_globals.METRICS["Percent"],
         measure_id=vi_globals.MEASURES["Deaths"],

--- a/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
@@ -8,8 +8,6 @@ components:
     vivarium_public_health:
         risks:
             - Risk('risk_factor.hemoglobin')
-            - NonLogLinearRiskEffect('risk_factor.hemoglobin', 'cause.maternal_hemorrhage.incidence_risk')
-            - NonLogLinearRiskEffect('risk_factor.hemoglobin', 'cause.maternal_sepsis_and_other_maternal_infections.incidence_risk')
 
     vivarium_gates_mncnh:
         components:
@@ -45,6 +43,8 @@ components:
             - InterventionAccess('azithromycin')
             - InterventionAccess('misoprostol')
             - PostpartumDepression()
+            - HemoglobinRiskEffect('risk_factor.hemoglobin', 'cause.maternal_hemorrhage.incidence_risk')
+            - HemoglobinRiskEffect('risk_factor.hemoglobin', 'cause.maternal_sepsis_and_other_maternal_infections.incidence_risk')
             # Add model observers below here
             - ANCObserver()
             - MaternalDisordersBurdenObserver()


### PR DESCRIPTION
## fix RR start and intervals and use location-specific PAFs

### Description
- *Category*: bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6242
- *Research reference*: [model 13.1](https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_mncnh_portfolio/concept_model.html#id26)

### Changes and notes
Update NonLogLinearRiskEffect to use max RR value for minimum exposure rather than minimum and don't clip RRs to be greater than or equal to 1.

### Verification and Testing
Plotted relative risk data and checked that relative risks stayed flat once exposure went below 40 and dipped below 1 once exposure went above 120.