### PR TITLE
model 13.2 paf weighting bugfix

### DIFF
--- a/src/vivarium_gates_mncnh/components/lbwsg.py
+++ b/src/vivarium_gates_mncnh/components/lbwsg.py
@@ -359,7 +359,13 @@ class LBWSGPAFObserver(Component):
 
     @property
     def columns_required(self) -> list[str] | None:
-        return ["lbwsg_category", "gestational_age_exposure", "age_bin", "child_alive", "sex_of_child"]
+        return [
+            "lbwsg_category",
+            "gestational_age_exposure",
+            "age_bin",
+            "child_alive",
+            "sex_of_child",
+        ]
 
     def __init__(self, target: str):
         super().__init__()
@@ -392,7 +398,7 @@ class LBWSGPAFObserver(Component):
         # Add observer to get paf for preterm birth population
         builder.results.register_adding_observation(
             name=f"calculated_lbwsg_paf_on_{self.target}_preterm",
-            pop_filter='gestational_age_exposure < 37',
+            pop_filter="gestational_age_exposure < 37",
             aggregator=self.calculate_paf,
             requires_columns=["child_alive", "gestational_age_exposure"],
             additional_stratifications=self.config.include,
@@ -463,9 +469,13 @@ class LBWSGPAFObserver(Component):
         full_index = pd.Index(range(self.pop_size))
         # sex is guaranteed to be the same for all simulants in the index because
         # we stratify by sex of child
-        sex_of_subset = self.population_view.get(index)['sex_of_child'].unique()[0]
-        pop_data = self.population_view.get(full_index)[["lbwsg_category", "child_alive", "sex_of_child"]]
-        pop_data = pop_data[pop_data['sex_of_child'] == sex_of_subset].drop('sex_of_child', axis=1)
+        sex_of_subset = self.population_view.get(index)["sex_of_child"].unique()[0]
+        pop_data = self.population_view.get(full_index)[
+            ["lbwsg_category", "child_alive", "sex_of_child"]
+        ]
+        pop_data = pop_data[pop_data["sex_of_child"] == sex_of_subset].drop(
+            "sex_of_child", axis=1
+        )
         weights = (
             pop_data.groupby("lbwsg_category")["child_alive"]
             .agg(proportion_alive=lambda x: (x == "alive").mean())

--- a/src/vivarium_gates_mncnh/data/lbwsg_paf.yaml
+++ b/src/vivarium_gates_mncnh/data/lbwsg_paf.yaml
@@ -28,7 +28,7 @@ configuration:
         end:
             year: 2022
             month: 1
-            day: 2
+            day: 10
         step_size: 8 # Days
     population:
         population_size: 194_996

--- a/src/vivarium_gates_mncnh/data/lbwsg_paf.yaml
+++ b/src/vivarium_gates_mncnh/data/lbwsg_paf.yaml
@@ -12,7 +12,7 @@ components:
 configuration:
     input_data:
         input_draw_number: 0
-        artifact_path: '/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/model12.0/pakistan.hdf'
+        artifact_path: '/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/model13.1/pakistan.hdf'
     interpolation:
         order: 0
         extrapolate: True
@@ -28,7 +28,7 @@ configuration:
         end:
             year: 2022
             month: 1
-            day: 10
+            day: 2
         step_size: 8 # Days
     population:
         population_size: 194_996


### PR DESCRIPTION
## model 13.2 paf weighting bugfix

### Description
- *Category*: bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6245

### Changes and notes
Bugfix to correctly weight LBWSG exposure by proportion of simulants who survived in each LBWSG category.

### Verification and Testing
Used breakpoint to check that weights were 1 in first time step and not 1 in the second timestep. 

