### PR TITLE
model 14 ANC observers

### DIFF
--- a/src/vivarium_gates_mncnh/components/antenatal_care.py
+++ b/src/vivarium_gates_mncnh/components/antenatal_care.py
@@ -186,7 +186,7 @@ class AntenatalCare(Component):
     def create_anc_decision_tree(self) -> TreeMachine:
         initial_state = State("initial")
         # DecisionTreeStates are TransientStates that update
-        # a population column value upon transition 
+        # a population column value upon transition
         state_A = DecisionTreeState(
             ANC_ATTENDANCE_TYPES.FIRST_TRIMESTER_AND_LATER_PREGNANCY,
             COLUMNS.ANC_ATTENDANCE,

--- a/src/vivarium_gates_mncnh/components/antenatal_care.py
+++ b/src/vivarium_gates_mncnh/components/antenatal_care.py
@@ -13,6 +13,7 @@ from vivarium.types import ClockTime
 from vivarium_gates_mncnh.components.tree import DecisionTreeState, TreeMachine
 from vivarium_gates_mncnh.constants.data_keys import ANC
 from vivarium_gates_mncnh.constants.data_values import (
+    ANC_ATTENDANCE_TYPES,
     ANC_RATES,
     COLUMNS,
     LOW_BIRTH_WEIGHT_THRESHOLD,
@@ -42,10 +43,12 @@ class AntenatalCare(Component):
     @property
     def columns_created(self):
         return [
-            COLUMNS.ANTENATAL_CARE_ATTENDANCE,
+            COLUMNS.ANC_ATTENDANCE,
             COLUMNS.ULTRASOUND_TYPE,
             COLUMNS.STATED_GESTATIONAL_AGE,
             COLUMNS.SUCCESSFUL_LBW_IDENTIFICATION,
+            COLUMNS.FIRST_TRIMESTER_ANC,
+            COLUMNS.LATER_PREGNANCY_ANC,
         ]
 
     @property
@@ -114,10 +117,12 @@ class AntenatalCare(Component):
     def on_initialize_simulants(self, pop_data: SimulantData) -> None:
         anc_data = pd.DataFrame(
             {
-                COLUMNS.ANTENATAL_CARE_ATTENDANCE: "none",  # no attendance
+                COLUMNS.ANC_ATTENDANCE: ANC_ATTENDANCE_TYPES.NONE,
                 COLUMNS.ULTRASOUND_TYPE: ULTRASOUND_TYPES.NO_ULTRASOUND,
                 COLUMNS.STATED_GESTATIONAL_AGE: np.nan,
                 COLUMNS.SUCCESSFUL_LBW_IDENTIFICATION: False,
+                COLUMNS.FIRST_TRIMESTER_ANC: False,
+                COLUMNS.LATER_PREGNANCY_ANC: False,
             },
             index=pop_data.index,
         )
@@ -130,6 +135,18 @@ class AntenatalCare(Component):
         pop = self.population_view.get(event.index)
         pop[COLUMNS.STATED_GESTATIONAL_AGE] = self._calculate_stated_gestational_age(pop)
         pop[COLUMNS.SUCCESSFUL_LBW_IDENTIFICATION] = self._determine_lbw_identification(pop)
+        pop[COLUMNS.FIRST_TRIMESTER_ANC] = pop[COLUMNS.ANC_ATTENDANCE].isin(
+            [
+                ANC_ATTENDANCE_TYPES.FIRST_TRIMESTER_ONLY,
+                ANC_ATTENDANCE_TYPES.FIRST_TRIMESTER_AND_LATER_PREGNANCY,
+            ]
+        )
+        pop[COLUMNS.LATER_PREGNANCY_ANC] = pop[COLUMNS.ANC_ATTENDANCE].isin(
+            [
+                ANC_ATTENDANCE_TYPES.LATER_PREGNANCY_ONLY,
+                ANC_ATTENDANCE_TYPES.FIRST_TRIMESTER_AND_LATER_PREGNANCY,
+            ]
+        )
 
         self.population_view.update(pop)
 
@@ -171,17 +188,25 @@ class AntenatalCare(Component):
         # DecisionTreeStates are TransientStates that update
         # a population column upon transition to a specified value
         state_A = DecisionTreeState(
-            "first_trimester_and_later_pregnancy",
-            COLUMNS.ANTENATAL_CARE_ATTENDANCE,
-            "first_trimester_and_later_pregnancy",
+            ANC_ATTENDANCE_TYPES.FIRST_TRIMESTER_AND_LATER_PREGNANCY,
+            COLUMNS.ANC_ATTENDANCE,
+            ANC_ATTENDANCE_TYPES.FIRST_TRIMESTER_AND_LATER_PREGNANCY,
         )
         state_B = DecisionTreeState(
-            "first_trimester_only", COLUMNS.ANTENATAL_CARE_ATTENDANCE, "first_trimester_only"
+            ANC_ATTENDANCE_TYPES.FIRST_TRIMESTER_ONLY,
+            COLUMNS.ANC_ATTENDANCE,
+            ANC_ATTENDANCE_TYPES.FIRST_TRIMESTER_ONLY,
         )
         state_C = DecisionTreeState(
-            "later_pregnancy_only", COLUMNS.ANTENATAL_CARE_ATTENDANCE, "later_pregnancy_only"
+            ANC_ATTENDANCE_TYPES.LATER_PREGNANCY_ONLY,
+            COLUMNS.ANC_ATTENDANCE,
+            ANC_ATTENDANCE_TYPES.LATER_PREGNANCY_ONLY,
         )
-        state_D = DecisionTreeState("none", COLUMNS.ANTENATAL_CARE_ATTENDANCE, "none")
+        state_D = DecisionTreeState(
+            ANC_ATTENDANCE_TYPES.NONE,
+            COLUMNS.ANC_ATTENDANCE,
+            ANC_ATTENDANCE_TYPES.NONE,
+        )
         gets_ultrasound = TransientState("gets_ultrasound")
         standard_ultasound = UltrasoundState(ULTRASOUND_TYPES.STANDARD)
         ai_assisted_ultrasound = UltrasoundState(ULTRASOUND_TYPES.AI_ASSISTED)

--- a/src/vivarium_gates_mncnh/components/intrapartum.py
+++ b/src/vivarium_gates_mncnh/components/intrapartum.py
@@ -8,6 +8,7 @@ from vivarium.framework.lookup import LookupTable
 from vivarium.framework.population import SimulantData
 
 from vivarium_gates_mncnh.constants.data_values import (
+    ANC_ATTENDANCE_TYPES,
     COLUMNS,
     DELIVERY_FACILITY_TYPES,
     INTERVENTION_TYPE_MAPPER,
@@ -26,7 +27,7 @@ INTERVENTION_TYPE_COLUMN_MAP = {
     "maternal": [
         COLUMNS.DELIVERY_FACILITY_TYPE,
         COLUMNS.MOTHER_AGE,
-        COLUMNS.ANTENATAL_CARE_ATTENDANCE,
+        COLUMNS.ANC_ATTENDANCE,
     ],
 }
 INTERVENTION_SCENARIO_ACCESS_MAP = {
@@ -163,7 +164,7 @@ class InterventionAccess(Component):
         # Misoprostol is only available to mothers who attended ANC and gave birth at home
         if self.intervention == INTERVENTIONS.MISOPROSTOL:
             pop = pop.loc[
-                (pop[COLUMNS.ANTENATAL_CARE_ATTENDANCE] != "none")  # attended ANC
+                (pop[COLUMNS.ANC_ATTENDANCE] != ANC_ATTENDANCE_TYPES.NONE)  # attended ANC
                 & (pop[COLUMNS.DELIVERY_FACILITY_TYPE] == DELIVERY_FACILITY_TYPES.HOME)
             ]
         return pop

--- a/src/vivarium_gates_mncnh/components/observers.py
+++ b/src/vivarium_gates_mncnh/components/observers.py
@@ -88,10 +88,10 @@ class ResultsStratifier(ResultsStratifier_):
         builder.results.register_stratification(
             "anc_coverage",
             [
-            ANC_ATTENDANCE_TYPES.NONE,
-            ANC_ATTENDANCE_TYPES.LATER_PREGNANCY_ONLY,
-            ANC_ATTENDANCE_TYPES.FIRST_TRIMESTER_ONLY,
-            ANC_ATTENDANCE_TYPES.FIRST_TRIMESTER_AND_LATER_PREGNANCY,
+                ANC_ATTENDANCE_TYPES.NONE,
+                ANC_ATTENDANCE_TYPES.LATER_PREGNANCY_ONLY,
+                ANC_ATTENDANCE_TYPES.FIRST_TRIMESTER_ONLY,
+                ANC_ATTENDANCE_TYPES.FIRST_TRIMESTER_AND_LATER_PREGNANCY,
             ],
             is_vectorized=True,
             requires_columns=[COLUMNS.ANC_ATTENDANCE],

--- a/src/vivarium_gates_mncnh/components/observers.py
+++ b/src/vivarium_gates_mncnh/components/observers.py
@@ -12,6 +12,7 @@ from vivarium_public_health.results import ResultsStratifier as ResultsStratifie
 
 from vivarium_gates_mncnh.constants.data_keys import POSTPARTUM_DEPRESSION
 from vivarium_gates_mncnh.constants.data_values import (
+    ANC_ATTENDANCE_TYPES,
     CAUSES_OF_NEONATAL_MORTALITY,
     COLUMNS,
     DELIVERY_FACILITY_TYPES,
@@ -87,10 +88,10 @@ class ResultsStratifier(ResultsStratifier_):
         builder.results.register_stratification(
             "anc_coverage",
             [
-                "none",
-                "later_pregnancy_only",
-                "first_trimester_only",
-                "first_trimester_and_later_pregnancy",
+            ANC_ATTENDANCE_TYPES.NONE,
+            ANC_ATTENDANCE_TYPES.LATER_PREGNANCY_ONLY,
+            ANC_ATTENDANCE_TYPES.FIRST_TRIMESTER_ONLY,
+            ANC_ATTENDANCE_TYPES.FIRST_TRIMESTER_AND_LATER_PREGNANCY,
             ],
             is_vectorized=True,
             requires_columns=[COLUMNS.ANC_ATTENDANCE],

--- a/src/vivarium_gates_mncnh/components/observers.py
+++ b/src/vivarium_gates_mncnh/components/observers.py
@@ -84,13 +84,17 @@ class ResultsStratifier(ResultsStratifier_):
             is_vectorized=True,
             requires_columns=[COLUMNS.DELIVERY_FACILITY_TYPE],
         )
-        # TODO: add back in with ANC observer updates [MIC-6297]
-        # builder.results.register_stratification(
-        #     "anc_coverage",
-        #     [True, False],
-        #     is_vectorized=True,
-        #     requires_columns=[COLUMNS.ANTENATAL_CARE_ATTENDANCE],
-        # )
+        builder.results.register_stratification(
+            "anc_coverage",
+            [
+                "none",
+                "later_pregnancy_only",
+                "first_trimester_only",
+                "first_trimester_and_later_pregnancy",
+            ],
+            is_vectorized=True,
+            requires_columns=[COLUMNS.ANC_ATTENDANCE],
+        )
         builder.results.register_stratification(
             "ultrasound_type",
             [

--- a/src/vivarium_gates_mncnh/constants/data_values.py
+++ b/src/vivarium_gates_mncnh/constants/data_values.py
@@ -125,6 +125,16 @@ class __UltrasoundTypes(NamedTuple):
 ULTRASOUND_TYPES = __UltrasoundTypes()
 
 
+class __ANCAttendanceTypes(NamedTuple):
+    NONE: str = "none"
+    LATER_PREGNANCY_ONLY: str = "later_pregnancy_only"
+    FIRST_TRIMESTER_ONLY: str = "first_trimester_only"
+    FIRST_TRIMESTER_AND_LATER_PREGNANCY: str = "first_trimester_and_later_pregnancy"
+
+
+ANC_ATTENDANCE_TYPES = __ANCAttendanceTypes()
+
+
 class __ANCRates(NamedTuple):
     ATTENDED_CARE_FACILITY = {
         "Ethiopia": 0.757,
@@ -182,12 +192,14 @@ class __Columns(NamedTuple):
     SEX_OF_CHILD = "sex_of_child"
     BIRTH_WEIGHT_EXPOSURE = "birth_weight_exposure"
     GESTATIONAL_AGE_EXPOSURE = "gestational_age_exposure"
-    ANTENATAL_CARE_ATTENDANCE = "antenatal_care_attendance"
+    ANC_STATE = "anc_state"
+    ANC_ATTENDANCE = "anc_attendance"
+    FIRST_TRIMESTER_ANC = "first_trimester_anc"
+    LATER_PREGNANCY_ANC = "later_pregnancy_anc"
     DELIVERY_FACILITY_TYPE = "delivery_facility_type"
     ULTRASOUND_TYPE = "ultrasound_type"
     STATED_GESTATIONAL_AGE = "stated_gestational_age"
     SUCCESSFUL_LBW_IDENTIFICATION = "successful_lbw_identification"
-    ANC_STATE = "anc_state"
     MATERNAL_SEPSIS = "maternal_sepsis_and_other_maternal_infections"
     MATERNAL_HEMORRHAGE = "maternal_hemorrhage"
     OBSTRUCTED_LABOR = "maternal_obstructed_labor_and_uterine_rupture"

--- a/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
@@ -45,8 +45,8 @@ components:
             - PostpartumDepression()
             - HemoglobinRiskEffect('risk_factor.hemoglobin', 'cause.maternal_hemorrhage.incidence_risk')
             - HemoglobinRiskEffect('risk_factor.hemoglobin', 'cause.maternal_sepsis_and_other_maternal_infections.incidence_risk')
-            # TODO: add back in with ANC observer updates [MIC-6297]
-            # - ANCObserver()
+            # Observers 
+            - ANCObserver()
             - MaternalDisordersBurdenObserver()
             - NeonatalBurdenObserver()
             - NeonatalCauseRelativeRiskObserver()
@@ -101,8 +101,7 @@ configuration:
             include:
                 - 'age_group'
                 - 'pregnancy_outcome'
-                # TODO: add back in with ANC observer updates [MIC-6297]
-                #- 'anc_coverage'
+                - 'anc_coverage'
                 - 'ultrasound_type'
                 - 'delivery_facility_type'
                 - 'azithromycin_availability'


### PR DESCRIPTION
## model 14 ANC observers

### Description
- *Category*: observers
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6297
- *Research reference*: [ANC model](https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_mncnh_portfolio/antenatal_care_module/module_document.html#module-outputs)

### Changes and notes
Update ANC_ATTENDANCE name to be more consistent with the other ANC names in COLUMNS.
Define two new columns: first trimester ANC and later pregnancy ANC.
Update attendance stratification. 
Use ANC_ATTENDANCE_TYPES constants.

### Verification and Testing
Looked at anc.parquet and checked that anc attendance column contained 'none', 'later_pregnancy', etc. 