### PR TITLE
LBWSG exposure correlated propensity updates

### DIFF
--- a/src/vivarium_gates_mncnh/components/lbwsg.py
+++ b/src/vivarium_gates_mncnh/components/lbwsg.py
@@ -91,11 +91,10 @@ class OrderedLBWSGDistribution(LBWSGDistribution_):
                 categorical_exposures.append(self.sex_specific_ppf(propensity, sex))
             categorical_exposure = pd.concat(categorical_exposures).sort_index()
 
-            exposure_intervals = categorical_exposure.apply(
-                lambda category: self.category_intervals[axis][category]
-            )
-
         # everything below here is unchanged from LBWSGDistribution
+        exposure_intervals = categorical_exposure.apply(
+            lambda category: self.category_intervals[axis][category]
+        )
         exposure_left = exposure_intervals.apply(lambda interval: interval.left)
         exposure_right = exposure_intervals.apply(lambda interval: interval.right)
         continuous_exposure = propensity * (exposure_right - exposure_left) + exposure_left

--- a/src/vivarium_gates_mncnh/components/lbwsg.py
+++ b/src/vivarium_gates_mncnh/components/lbwsg.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
-from layered_config_tree import ConfigurationError
 from vivarium.component import Component
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
@@ -17,6 +16,10 @@ from vivarium.framework.resource import Resource
 from vivarium.framework.values import Pipeline, list_combiner, union_post_processor
 from vivarium_public_health.risks.data_transformations import (
     get_exposure_post_processor,
+)
+from vivarium_public_health.risks.distributions import MissingDataError
+from vivarium_public_health.risks.implementations.low_birth_weight_and_short_gestation import (
+    LBWSGDistribution as LBWSGDistribution_,
 )
 from vivarium_public_health.risks.implementations.low_birth_weight_and_short_gestation import (
     LBWSGRisk as LBWSGRisk_,
@@ -42,7 +45,80 @@ BIRTH_WEIGHT = "birth_weight"
 GESTATIONAL_AGE = "gestational_age"
 
 
+class OrderedLBWSGDistribution(LBWSGDistribution_):
+    AXES = [BIRTH_WEIGHT, GESTATIONAL_AGE]
+
+    @property
+    def columns_required(self) -> list[str]:
+        return [
+            COLUMNS.SEX_OF_CHILD,
+        ]
+
+    def setup(self, builder: Builder) -> None:
+        super().setup(builder)
+        self.ordered_categories = builder.data.load(
+            data_keys.LBWSG.SEX_SPECIFIC_ORDERED_CATEGORIES
+        )
+
+    # updated to use sex-specific ordered categories
+    def single_axis_ppf(
+        self,
+        axis: str,
+        propensity: pd.Series,
+        categorical_propensity: pd.Series | None = None,
+        categorical_exposure: pd.Series | None = None,
+    ) -> pd.Series:
+        if (categorical_propensity is None) == (categorical_exposure is None):
+            raise ValueError(
+                "Exactly one of categorical propensity or categorical exposure "
+                "must be provided."
+            )
+
+        if categorical_exposure is None:
+            # everything above here is unchanged from LBWSGDistribution
+            categorical_exposures = []
+            for sex in ["Male", "Female"]:
+                pop = self.population_view.get(propensity.index)
+                sex_subset_index = pop.loc[pop[COLUMNS.SEX_OF_CHILD] == sex].index
+                categorical_exposures.append(
+                    self.sex_specific_ppf(propensity.loc[sex_subset_index], sex)
+                )
+            categorical_exposure = pd.concat(categorical_exposures).sort_index()
+
+            exposure_intervals = categorical_exposure.apply(
+                lambda category: self.category_intervals[axis][category]
+            )
+
+        # everything below here is unchanged from LBWSGDistribution
+        exposure_left = exposure_intervals.apply(lambda interval: interval.left)
+        exposure_right = exposure_intervals.apply(lambda interval: interval.right)
+        continuous_exposure = propensity * (exposure_right - exposure_left) + exposure_left
+        continuous_exposure = continuous_exposure.rename(f"{axis}.exposure")
+        return continuous_exposure
+
+    def sex_specific_ppf(self, quantiles: pd.Series, sex: str) -> pd.Series:
+        exposure = self.exposure_parameters(quantiles.index)
+        # these two lines and the signature update are the only changes
+        # from the PolytomousDistribution function
+        # from self.categories to sex_specific_ordering
+        sex_specific_ordering = self.ordered_categories[sex]
+        sorted_exposures = exposure[sex_specific_ordering]
+        if not np.allclose(1, np.sum(sorted_exposures, axis=1)):
+            raise MissingDataError("All exposure data returned as 0.")
+        exposure_sum = sorted_exposures.cumsum(axis="columns")
+        category_index = pd.concat(
+            [exposure_sum[c] < quantiles for c in exposure_sum.columns], axis=1
+        ).sum(axis=1)
+        return pd.Series(
+            np.array(self.categories)[category_index],
+            name=self.risk + ".exposure",
+            index=quantiles.index,
+        )
+
+
 class LBWSGRisk(LBWSGRisk_):
+    exposure_distributions = {"lbwsg": OrderedLBWSGDistribution}
+
     @property
     def columns_required(self) -> list[str]:
         return [
@@ -58,8 +134,20 @@ class LBWSGRisk(LBWSGRisk_):
     def setup(self, builder: Builder) -> None:
         super().setup(builder)
         # We have to override the age_end due to the wide state table and this is easier than
-        # adding an extra population configuratio key
+        # adding an extra population configuration key
         self.configuration_age_end = 0.0
+        self.categorical_propensity = builder.value.get_value(
+            f"{self.name}.correlated_propensity"
+        )
+
+    def get_birth_exposure(self, axis: str, index: pd.Index) -> pd.DataFrame:
+        categorical_propensity = self.categorical_propensity(
+            index
+        )  # only line change in this subclassed function
+        continuous_propensity = self.randomness.get_draw(index, additional_key=axis)
+        return self.exposure_distribution.single_axis_ppf(
+            axis, continuous_propensity, categorical_propensity
+        )
 
 
 class LBWSGRiskEffect(LBWSGRiskEffect_):

--- a/src/vivarium_gates_mncnh/components/lbwsg.py
+++ b/src/vivarium_gates_mncnh/components/lbwsg.py
@@ -88,7 +88,9 @@ class OrderedLBWSGDistribution(LBWSGDistribution_):
             # everything above here is unchanged from LBWSGDistribution
             categorical_exposures = []
             for sex in ["Male", "Female"]:
-                categorical_exposures.append(self.sex_specific_ppf(propensity, sex))
+                categorical_exposures.append(
+                    self.sex_specific_ppf(categorical_propensity, sex)
+                )
             categorical_exposure = pd.concat(categorical_exposures).sort_index()
 
         # everything below here is unchanged from LBWSGDistribution
@@ -118,7 +120,7 @@ class OrderedLBWSGDistribution(LBWSGDistribution_):
             [exposure_sum[c] < quantiles for c in exposure_sum.columns], axis=1
         ).sum(axis=1)
         return pd.Series(
-            np.array(self.categories)[category_index],
+            np.array(sex_specific_ordering)[category_index],
             name=self.risk + ".exposure",
             index=quantiles.index,
         )

--- a/src/vivarium_gates_mncnh/components/lbwsg.py
+++ b/src/vivarium_gates_mncnh/components/lbwsg.py
@@ -46,6 +46,8 @@ GESTATIONAL_AGE = "gestational_age"
 
 
 class OrderedLBWSGDistribution(LBWSGDistribution_):
+    """This class allows us to use sex-specific custom ordering for our LBWSG categories
+    when determining exposure."""
     AXES = [BIRTH_WEIGHT, GESTATIONAL_AGE]
 
     @property
@@ -54,13 +56,20 @@ class OrderedLBWSGDistribution(LBWSGDistribution_):
             COLUMNS.SEX_OF_CHILD,
         ]
 
+    #################
+    # Setup methods #
+    #################
+
     def setup(self, builder: Builder) -> None:
         super().setup(builder)
         self.ordered_categories = builder.data.load(
             data_keys.LBWSG.SEX_SPECIFIC_ORDERED_CATEGORIES
         )
 
-    # updated to use sex-specific ordered categories
+    ##################
+    # Public methods #
+    ##################
+
     def single_axis_ppf(
         self,
         axis: str,
@@ -95,6 +104,7 @@ class OrderedLBWSGDistribution(LBWSGDistribution_):
         continuous_exposure = propensity * (exposure_right - exposure_left) + exposure_left
         continuous_exposure = continuous_exposure.rename(f"{axis}.exposure")
         return continuous_exposure
+
 
     def sex_specific_ppf(self, quantiles: pd.Series, sex: str) -> pd.Series:
         exposure = self.exposure_parameters(quantiles.index)

--- a/src/vivarium_gates_mncnh/components/lbwsg.py
+++ b/src/vivarium_gates_mncnh/components/lbwsg.py
@@ -19,7 +19,7 @@ from vivarium_public_health.risks.data_transformations import (
 )
 from vivarium_public_health.risks.distributions import MissingDataError
 from vivarium_public_health.risks.implementations.low_birth_weight_and_short_gestation import (
-    LBWSGDistribution as LBWSGDistribution_,
+    LBWSGDistribution,
 )
 from vivarium_public_health.risks.implementations.low_birth_weight_and_short_gestation import (
     LBWSGRisk as LBWSGRisk_,
@@ -45,7 +45,7 @@ BIRTH_WEIGHT = "birth_weight"
 GESTATIONAL_AGE = "gestational_age"
 
 
-class OrderedLBWSGDistribution(LBWSGDistribution_):
+class OrderedLBWSGDistribution(LBWSGDistribution):
     """This class allows us to use sex-specific custom ordering for our LBWSG categories
     when determining exposure."""
 

--- a/src/vivarium_gates_mncnh/constants/data_keys.py
+++ b/src/vivarium_gates_mncnh/constants/data_keys.py
@@ -57,6 +57,9 @@ class __LowBirthWeightShortGestation(NamedTuple):
     EXPOSURE: str = "risk_factor.low_birth_weight_and_short_gestation.exposure"
     DISTRIBUTION: str = "risk_factor.low_birth_weight_and_short_gestation.distribution"
     CATEGORIES: str = "risk_factor.low_birth_weight_and_short_gestation.categories"
+    SEX_SPECIFIC_ORDERED_CATEGORIES: str = (
+        "risk_factor.low_birth_weight_and_short_gestation.sex_specific_ordered_categories"
+    )
     RELATIVE_RISK: str = "risk_factor.low_birth_weight_and_short_gestation.relative_risk"
     RELATIVE_RISK_INTERPOLATOR: str = (
         "risk_factor.low_birth_weight_and_short_gestation.relative_risk_interpolator"

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -569,11 +569,13 @@ def load_sex_specific_ordered_lbwsg_categories(
     rrs = rrs.mean(axis=1)
     categories = get_data(data_keys.LBWSG.CATEGORIES, location)
     # Get preterm categories
-    preterm_cats = []
+    preterm_cats, full_term_cats = [], []
     for cat, description in categories.items():
         i = utilities.parse_short_gestation_description(description)
         if i.right <= metadata.PRETERM_AGE_CUTOFF:
             preterm_cats.append(cat)
+        else:
+            full_term_cats.append(cat)
 
     ordered_cats = {}
     for sex in ["Male", "Female"]:


### PR DESCRIPTION
## LBWSG exposure correlated propensity updates

### Description
- *Category*: feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6317
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/other_models/facility_choice/index.html#special-ordering-of-the-categories-for-categorical-variables

### Changes and notes
Update LBWSGRisk to get categorical propensity from CorrelatedPropensities component and use new OrderedLBWSGDistribution.
Define new OrderedLBWSGDistribution that can handle sex-specific categorical orderings.
Add new key to artifact which contains a dictionary of category orderings for each sex.

### Verification and Testing
Built artifact for Ethiopia. Ran a time step and checked that categories were ordered as desired when directly using propensity. 

