### PR TITLE
artifact update for ACS PAF 

### DIFF
--- a/src/vivarium_gates_mncnh/constants/data_keys.py
+++ b/src/vivarium_gates_mncnh/constants/data_keys.py
@@ -240,6 +240,22 @@ class __NoCPAPRisk(NamedTuple):
 NO_CPAP_RISK = __NoCPAPRisk()
 
 
+class __NoACSRisk(NamedTuple):
+    # Keys that will be loaded into the artifact. must have a colon type declaration
+    RELATIVE_RISK: str = "intervention.no_acs_risk.relative_risk"
+
+    @property
+    def name(self):
+        return "no_acs_risk"
+
+    @property
+    def log_name(self):
+        return "no ACS risk"
+
+
+NO_ACS_RISK = __NoACSRisk()
+
+
 class __FacilityChoice(NamedTuple):
     P_HOME_PRETERM: str = "cause.facility_choice.probability_home_birth_given_preterm"
     P_HOME_FULL_TERM: str = "cause.facility_choice.probability_home_birth_given_full_term"

--- a/src/vivarium_gates_mncnh/constants/data_keys.py
+++ b/src/vivarium_gates_mncnh/constants/data_keys.py
@@ -243,6 +243,7 @@ NO_CPAP_RISK = __NoCPAPRisk()
 class __NoACSRisk(NamedTuple):
     # Keys that will be loaded into the artifact. must have a colon type declaration
     RELATIVE_RISK: str = "intervention.no_acs_risk.relative_risk"
+    PAF: str = "intervention.no_acs_risk.population_attributable_fraction"
 
     @property
     def name(self):
@@ -419,6 +420,7 @@ MAKE_ARTIFACT_KEY_GROUPS = [
     NEONATAL_SEPSIS,
     NEONATAL_ENCEPHALOPATHY,
     NO_CPAP_RISK,
+    NO_ACS_RISK,
     FACILITY_CHOICE,
     NO_ANTIBIOTICS_RISK,
     NO_PROBIOTICS_RISK,

--- a/src/vivarium_gates_mncnh/constants/data_values.py
+++ b/src/vivarium_gates_mncnh/constants/data_values.py
@@ -320,6 +320,11 @@ DELIVERY_FACILITY_TYPE_PROBABILITIES = {
         FACILITY_CHOICE.P_BEmONC: 0.340528,
     },
 }
+PROPORTION_IN_FACILITY_DELIVERIES = {
+    "Ethiopia": 0.492568,
+    "Nigeria": 0.520097,
+    "Pakistan": 0.771766,
+}
 # Probability each of these facility types has access to CPAP
 CPAP_ACCESS_PROBABILITIES = {
     "Ethiopia": {

--- a/src/vivarium_gates_mncnh/constants/data_values.py
+++ b/src/vivarium_gates_mncnh/constants/data_values.py
@@ -340,6 +340,8 @@ CPAP_ACCESS_PROBABILITIES = {
 }
 CPAP_RELATIVE_RISK_DISTRIBUTION = get_lognorm_from_quantiles(0.53, 0.34, 0.83)
 
+ACS_RELATIVE_RISK_DISTRIBUTION = get_lognorm_from_quantiles(0.84, 0.72, 0.97)
+
 
 ANTIBIOTIC_FACILITY_TYPE_DISTRIBUTION = {
     # NOTE: This is not being used as of model 8.3


### PR DESCRIPTION
## artifact update for ACS PAF 

### Description
- *Category*: artifact
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6326
- *Research reference*: [alternative PAF derivation](https://vivarium-research.readthedocs.io/en/latest/models/intervention_models/neonatal/cpap_intervention.html#calibration-strategy)

### Changes and notes
Update CPAP and ACS PAF. 
Note that the documentation lacks some details that were used in calculation. In particular, the fact that P(BEmONC) = p(facility) * p(BEmONC|facility) (and analogously for CEmONC) and that the probability of CPAP is marginalized over facility choice.

### Verification and Testing
Built artifact for Ethiopia and checked that the structure was the same as for other intervention PAFs.