### PR TITLE
model 16.2 bugfixes

### DIFF
--- a/src/vivarium_gates_mncnh/components/__init__.py
+++ b/src/vivarium_gates_mncnh/components/__init__.py
@@ -1,7 +1,10 @@
 from vivarium_gates_mncnh.components.antenatal_care import AntenatalCare
 from vivarium_gates_mncnh.components.delivery_facility import DeliveryFacility
 from vivarium_gates_mncnh.components.hemoglobin import HemoglobinRiskEffect
-from vivarium_gates_mncnh.components.intervention import InterventionRiskEffect
+from vivarium_gates_mncnh.components.intervention import (
+    CPAPAndACSRiskEffect,
+    InterventionRiskEffect,
+)
 from vivarium_gates_mncnh.components.intrapartum import ACSAccess, InterventionAccess
 from vivarium_gates_mncnh.components.lbwsg import (
     LBWSGMortality,

--- a/src/vivarium_gates_mncnh/components/intervention.py
+++ b/src/vivarium_gates_mncnh/components/intervention.py
@@ -135,15 +135,17 @@ class CPAPAndACSRiskEffect(Component):
         no_cpap_index = pop.index[has_no_cpap & ~in_acs_gestational_age_range]
 
         no_intervention_rr = pd.Series(1.0, index=index)
-        no_intervention_paf = self.lookup_tables["no_cpap_paf"](index)
-
         no_intervention_rr.loc[no_cpap_index] = self.lookup_tables["no_cpap_relative_risk"](
             no_cpap_index
         )
         no_intervention_rr.loc[no_acs_index] = self.lookup_tables["no_acs_relative_risk"](
             no_acs_index
         ) * self.lookup_tables["no_cpap_relative_risk"](no_acs_index)
-        no_intervention_paf.loc[no_acs_index] = self.lookup_tables["no_acs_paf"](no_acs_index)
+
+        no_intervention_paf = self.lookup_tables["no_cpap_paf"](index)
+        no_intervention_paf.loc[in_acs_gestational_age_range] = self.lookup_tables[
+            "no_acs_paf"
+        ](no_acs_index)
 
         target_pipeline.loc[no_intervention_index] = (
             target_pipeline.loc[no_intervention_index]

--- a/src/vivarium_gates_mncnh/components/intervention.py
+++ b/src/vivarium_gates_mncnh/components/intervention.py
@@ -5,7 +5,7 @@ from vivarium import Component
 from vivarium.framework.engine import Builder
 from vivarium_public_health.utilities import get_lookup_columns
 
-from vivarium_gates_mncnh.constants.data_values import INTERVENTIONS, PIPELINES
+from vivarium_gates_mncnh.constants.data_values import COLUMNS, INTERVENTIONS, PIPELINES
 
 
 class InterventionRiskEffect(Component):
@@ -14,8 +14,6 @@ class InterventionRiskEffect(Component):
 
     INTERVENTION_PIPELINE_MODIFIERS_MAP = {
         # TODO: add neonatal interventions below here
-        INTERVENTIONS.ACS: PIPELINES.PRETERM_WITH_RDS_FINAL_CSMR,
-        INTERVENTIONS.CPAP: PIPELINES.PRETERM_WITH_RDS_FINAL_CSMR,
         INTERVENTIONS.ANTIBIOTICS: PIPELINES.NEONATAL_SEPSIS_FINAL_CSMR,
         INTERVENTIONS.PROBIOTICS: PIPELINES.NEONATAL_SEPSIS_FINAL_CSMR,
         # TODO: add maternal interventions below here
@@ -78,8 +76,78 @@ class InterventionRiskEffect(Component):
         no_intervention_rr = self.lookup_tables["relative_risk"](no_intervention_idx)
         # NOTE: PAF is for no intervention
         paf = self.lookup_tables["paf"](index)
-
         # Modify the pipeline
         modified_pipeline = target_pipeline * (1 - paf)
         modified_pipeline.loc[no_intervention_idx] = modified_pipeline * no_intervention_rr
         return modified_pipeline
+
+
+class CPAPAndACSRiskEffect(Component):
+    @property
+    def configuration_defaults(self) -> dict:
+        return {
+            self.name: {
+                "data_sources": {
+                    "no_cpap_relative_risk": f"intervention.no_cpap_risk.relative_risk",
+                    "no_cpap_paf": f"intervention.no_cpap_risk.population_attributable_fraction",
+                    "no_acs_relative_risk": f"intervention.no_acs_risk.relative_risk",
+                    "no_acs_paf": f"intervention.no_acs_risk.population_attributable_fraction",
+                }
+            }
+        }
+
+    @property
+    def columns_required(self) -> list[str]:
+        return [COLUMNS.CPAP_AVAILABLE, COLUMNS.ACS_AVAILABLE, COLUMNS.STATED_GESTATIONAL_AGE]
+
+    @property
+    def target_pipeline_name(self) -> str:
+        return PIPELINES.PRETERM_WITH_RDS_FINAL_CSMR
+
+    def setup(self, builder: Builder) -> None:
+        self.randomness = builder.randomness.get_stream(self.name)
+        builder.value.register_value_modifier(
+            self.target_pipeline_name,
+            self.modify_target_pipeline,
+            component=self,
+            required_resources=self.columns_required
+            + get_lookup_columns(
+                [
+                    self.lookup_tables["no_cpap_relative_risk"],
+                    self.lookup_tables["no_cpap_paf"],
+                    self.lookup_tables["no_acs_relative_risk"],
+                    self.lookup_tables["no_acs_paf"],
+                ]
+            ),
+        )
+
+    def modify_target_pipeline(
+        self, index: pd.Index, target_pipeline: pd.Series[float]
+    ) -> pd.Series[float]:
+        pop = self.population_view.get(index)
+        in_acs_gestational_age_range = pop[COLUMNS.STATED_GESTATIONAL_AGE].between(
+            26, 33, inclusive="left"
+        )
+        has_no_cpap = pop[COLUMNS.CPAP_AVAILABLE] == False
+
+        no_intervention_index = has_no_cpap.index
+        no_acs_index = pop.index[has_no_cpap & in_acs_gestational_age_range]
+        no_cpap_index = pop.index[has_no_cpap & ~in_acs_gestational_age_range]
+
+        no_intervention_rr = pd.Series(1.0, index=index)
+        no_intervention_paf = self.lookup_tables["no_cpap_paf"](index)
+
+        no_intervention_rr.loc[no_cpap_index] = self.lookup_tables["no_cpap_relative_risk"](
+            no_cpap_index
+        )
+        no_intervention_rr.loc[no_acs_index] = self.lookup_tables["no_acs_relative_risk"](
+            no_acs_index
+        ) * self.lookup_tables["no_cpap_relative_risk"](no_acs_index)
+        no_intervention_paf.loc[no_acs_index] = self.lookup_tables["no_acs_paf"](no_acs_index)
+
+        target_pipeline.loc[no_intervention_index] = (
+            target_pipeline.loc[no_intervention_index]
+            * (1 - no_intervention_paf)
+            * no_intervention_rr
+        )
+        return target_pipeline

--- a/src/vivarium_gates_mncnh/components/observers.py
+++ b/src/vivarium_gates_mncnh/components/observers.py
@@ -136,6 +136,18 @@ class ResultsStratifier(ResultsStratifier_):
             requires_columns=[COLUMNS.GESTATIONAL_AGE_EXPOSURE],
         )
         builder.results.register_stratification(
+            "acs_eligibility",
+            [True, False],
+            mapper=self.map_acs_eligibility,
+            is_vectorized=True,
+            requires_columns=[COLUMNS.STATED_GESTATIONAL_AGE],
+        )
+        builder.results.register_stratification(
+            "acs_availability",
+            [True, False],
+            requires_columns=[COLUMNS.ACS_AVAILABLE],
+        )
+        builder.results.register_stratification(
             "azithromycin_availability",
             [True, False],
             requires_columns=[COLUMNS.AZITHROMYCIN_AVAILABLE],
@@ -165,6 +177,10 @@ class ResultsStratifier(ResultsStratifier_):
     def map_believed_preterm(self, pop: pd.DataFrame) -> pd.Series:
         preterm_births = pop[COLUMNS.STATED_GESTATIONAL_AGE] < PRETERM_AGE_CUTOFF
         return preterm_births.rename("believed_preterm")
+
+    def map_acs_eligibility(self, pop: pd.DataFrame) -> pd.Series:
+        is_eligible = pop[COLUMNS.STATED_GESTATIONAL_AGE].between(26, 33)
+        return is_eligible.rename("acs_eligibility")
 
 
 class PAFResultsStratifier(ResultsStratifier_):

--- a/src/vivarium_gates_mncnh/components/propensity.py
+++ b/src/vivarium_gates_mncnh/components/propensity.py
@@ -7,7 +7,7 @@ from statsmodels.distributions.copula.api import GaussianCopula
 from vivarium import Component
 from vivarium.framework.engine import Builder
 
-from vivarium_gates_mncnh.constants import data_values
+from vivarium_gates_mncnh.constants import data_keys, data_values
 
 
 class CorrelatedPropensities(Component):
@@ -26,6 +26,9 @@ class CorrelatedPropensities(Component):
     def setup(self, builder: Builder):
         self.component_names = builder.configuration.correlated_propensity_components
         self.pop_size = builder.configuration.population.population_size
+        self.correlations = builder.data.load(
+            data_keys.PROPENSITY_CORRELATIONS.PROPENSITY_CORRELATIONS
+        )
         self.propensities = self.get_all_propensities()
 
         for component in self.component_names:
@@ -42,8 +45,8 @@ class CorrelatedPropensities(Component):
         # create symmetric matrix with diagonals on the 1
         for (name1, name2) in pairs:
             # first key lexiographically is first element of tuple
-            correlation = data_values.PROPENSITY_CORRELATIONS[
-                (min(name1, name2), max(name1, name2))
+            correlation = self.correlations[
+                f"{(min(name1, name2))}_AND_{(max(name1, name2))}"
             ]
             i, j = name_to_index[name1], name_to_index[name2]
             # symmetric matrix

--- a/src/vivarium_gates_mncnh/constants/data_keys.py
+++ b/src/vivarium_gates_mncnh/constants/data_keys.py
@@ -280,6 +280,21 @@ class __FacilityChoice(NamedTuple):
 FACILITY_CHOICE = __FacilityChoice()
 
 
+class __PropensityCorrelations(NamedTuple):
+    PROPENSITY_CORRELATIONS: str = "propensity.correlations"
+
+    @property
+    def name(self):
+        return "propensity_correlations"
+
+    @property
+    def log_name(self):
+        return "propensity_correlations"
+
+
+PROPENSITY_CORRELATIONS = __PropensityCorrelations()
+
+
 class __NoAntibioticsRisk(NamedTuple):
     P_ANTIBIOTIC_HOME: str = "intervention.no_antibiotics_risk.probability_antibiotics_home"
     P_ANTIBIOTIC_BEMONC: str = (
@@ -500,6 +515,7 @@ MAKE_ARTIFACT_KEY_GROUPS = [
     NO_CPAP_RISK,
     NO_ACS_RISK,
     FACILITY_CHOICE,
+    PROPENSITY_CORRELATIONS,
     NO_ANTIBIOTICS_RISK,
     NO_PROBIOTICS_RISK,
     NO_AZITHROMYCIN_RISK,

--- a/src/vivarium_gates_mncnh/constants/data_values.py
+++ b/src/vivarium_gates_mncnh/constants/data_values.py
@@ -463,14 +463,23 @@ POSTPARTUM_DEPRESSION_CASE_DURATION = get_truncnorm(
     0.65, ninety_five_pct_confidence_interval=(0.59, 0.70)
 )
 
+
 PROPENSITY_CORRELATIONS = {
-    tuple(sorted(["antenatal_care", "delivery_facility"])): 0.63,
-    tuple(
-        sorted(["antenatal_care", "risk_factor.low_birth_weight_and_short_gestation"])
-    ): 0.2,
-    tuple(
-        sorted(["delivery_facility", "risk_factor.low_birth_weight_and_short_gestation"])
-    ): 0.2,
+    "Ethiopia": {
+        "antenatal_care_AND_delivery_facility": 0.63,
+        "antenatal_care_AND_risk_factor.low_birth_weight_and_short_gestation": 0.2,
+        "delivery_facility_AND_risk_factor.low_birth_weight_and_short_gestation": 0.2,
+    },
+    "Nigeria": {
+        "antenatal_care_AND_delivery_facility": 0.41,
+        "antenatal_care_AND_risk_factor.low_birth_weight_and_short_gestation": 0.2,
+        "delivery_facility_AND_risk_factor.low_birth_weight_and_short_gestation": 0.2,
+    },
+    "Pakistan": {
+        "antenatal_care_AND_delivery_facility": 0.35,
+        "antenatal_care_AND_risk_factor.low_birth_weight_and_short_gestation": 0.2,
+        "delivery_facility_AND_risk_factor.low_birth_weight_and_short_gestation": 0.2,
+    },
 }
 
 

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -149,6 +149,7 @@ def get_data(
         data_keys.HEMOGLOBIN.PAF: load_hemoglobin_paf,
         data_keys.HEMOGLOBIN.TMRED: load_hemoglobin_tmred,
         data_keys.IV_IRON.HEMOGLOBIN_EFFECT_SIZE: load_iv_iron_hemoglobin_effect_size,
+        data_keys.PROPENSITY_CORRELATIONS.PROPENSITY_CORRELATIONS: load_propensity_correlations,
     }
 
     data = mapping[lookup_key](lookup_key, location, years)
@@ -1362,6 +1363,12 @@ def load_hemoglobin_tmred(
     key: str, location: str, years: Optional[Union[int, str, List[int]]] = None
 ) -> dict[str, str | bool | float]:
     return {"distribution": "uniform", "min": 120.0, "max": 120.0}
+
+
+def load_propensity_correlations(
+    key: str, location: str, years: Optional[Union[int, str, List[int]]] = None
+) -> None:
+    return data_values.PROPENSITY_CORRELATIONS[location]
 
 
 def reshape_to_vivarium_format(df, location):

--- a/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
@@ -31,8 +31,7 @@ components:
             - NeonatalCause('neonatal_sepsis_and_other_neonatal_infections')
             - NeonatalCause('neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma')
             - NeonatalMortality()
-            - InterventionRiskEffect('cpap')
-            - InterventionRiskEffect('acs')
+            - CPAPAndACSRiskEffect()
             - InterventionRiskEffect('antibiotics')
             - InterventionRiskEffect('probiotics')
             - InterventionRiskEffect('azithromycin')
@@ -63,7 +62,7 @@ components:
 configuration:
     input_data:
         input_draw_number: 0
-        artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/model16.0/ethiopia.hdf"
+        artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/model16.2/ethiopia.hdf"
     interpolation:
         order: 0
         extrapolate: True
@@ -107,16 +106,22 @@ configuration:
                 - 'pregnancy_outcome'
                 - 'anc_coverage'
                 - 'ultrasound_type'
-                - 'delivery_facility_type'
                 - 'azithromycin_availability'
                 - 'misoprostol_availability'
+                - 'delivery_facility_type'
+                - 'preterm_birth'
                 - 'believed_preterm'
+                - 'acs_eligibility'
         birth:
             include:
                 - 'child_sex'
                 - 'delivery_facility_type'
                 - 'pregnancy_outcome'
-                - 'preterm_birth'
+                - 'antibiotics_availability'
+                - 'probiotics_availability'
+                - 'cpap_availability'
+                - 'acs_availability'
+                - 'acs_eligibility'
         maternal_disorders_burden:
             include:
                 - 'age_group'
@@ -126,13 +131,14 @@ configuration:
                 - 'misoprostol_availability'
         neonatal_burden:
             include:
-                - 'child_age_group'
                 - 'child_sex'
+                - 'child_age_group'
+                - 'delivery_facility_type'
                 - 'cpap_availability'
                 - 'antibiotics_availability'
                 - 'probiotics_availability'
-                - 'delivery_facility_type'
-                - 'preterm_birth'
+                - 'acs_availability'
+                - 'acs_eligibility'
         neonatal_cause_relative_risk:
             include:
                 - 'child_age_group'


### PR DESCRIPTION
## model 16.2 bugfixes

### Description
- *Category*: bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6400
- *Research reference*: [observers](https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_mncnh_portfolio/concept_model.html#id24), [propensity correlations](https://vivarium-research.readthedocs.io/en/latest/models/other_models/facility_choice/index.html#id6), [ACS intervention](https://vivarium-research.readthedocs.io/en/latest/models/intervention_models/intrapartum/acs_intervention.html#vivarium-modeling-strategy)

### Changes and notes
Make propensity correlations location-specific by placing them into artifact. Change tuples to strings so they can be stored in artifact.
Update stratifications in observers.
Handle CPAP and ACS risk effect so that we don't apply no_ACS_RR to simulants who aren't eligible for ACS.

### Verification and Testing
Ran simulation and checked 1) correlation matrix values and 2) births, ANC and neonatal death results for correct stratifications.
