### PR TITLE
model 16.4 CPAP_ACS risk effect bugfix 

### DIFF
--- a/src/vivarium_gates_mncnh/components/intervention.py
+++ b/src/vivarium_gates_mncnh/components/intervention.py
@@ -145,6 +145,7 @@ class CPAPAndACSRiskEffect(Component):
         no_acs_index = pop.index[has_no_cpap & in_acs_gestational_age_range]
         no_cpap_index = pop.index[has_no_cpap & ~in_acs_gestational_age_range]
 
+        # define RR
         no_intervention_rr = pd.Series(1.0, index=index)
         no_intervention_rr.loc[no_cpap_index] = self.lookup_tables["no_cpap_relative_risk"](
             no_cpap_index
@@ -153,14 +154,18 @@ class CPAPAndACSRiskEffect(Component):
             no_acs_index
         ) * self.lookup_tables["no_cpap_relative_risk"](no_acs_index)
 
+        # define PAF
         no_intervention_paf = self.lookup_tables["no_cpap_paf"](index)
+        in_acs_ga_range_index = pop.index[in_acs_gestational_age_range]
         no_intervention_paf.loc[in_acs_gestational_age_range] = self.lookup_tables[
             "no_acs_paf"
-        ](no_acs_index)
+        ](in_acs_ga_range_index)
 
+        # update pipeline
         target_pipeline.loc[no_intervention_index] = (
             target_pipeline.loc[no_intervention_index]
             * (1 - no_intervention_paf)
             * no_intervention_rr
         )
+
         return target_pipeline

--- a/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
@@ -139,6 +139,7 @@ configuration:
                 - 'probiotics_availability'
                 - 'acs_availability'
                 - 'acs_eligibility'
+                - 'preterm_birth'
         neonatal_cause_relative_risk:
             include:
                 - 'child_age_group'


### PR DESCRIPTION
## model 16.4 CPAP_ACS risk effect bugfix 

### Description
- *Category*: bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6409
- *Research reference*: [observers](https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_mncnh_portfolio/concept_model.html#id23)

### Changes and notes
Use aligned indexes when updating PAFs for ACS-eligible simulants.

### Verification and Testing
Checked that pipeline contained no missing values after update.   
