### PR TITLE
Model 18 - split up hemoglobin exposure and update oral iron effects

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
         "vivarium_build_utils>=2.0.1,<3.0.0",
         "gbd_mapping>=4.0.0",
         "layered_config_tree",
-        "vivarium>=3.4.5,<3.5.0",
+        "vivarium>=3.4.5,<4.0.0",
         "vivarium_public_health>=4.3.4,<5.0.0",
         "click",
         "jinja2",

--- a/src/vivarium_gates_mncnh/components/__init__.py
+++ b/src/vivarium_gates_mncnh/components/__init__.py
@@ -1,6 +1,6 @@
 from vivarium_gates_mncnh.components.antenatal_care import AntenatalCare
 from vivarium_gates_mncnh.components.delivery_facility import DeliveryFacility
-from vivarium_gates_mncnh.components.hemoglobin import HemoglobinRiskEffect
+from vivarium_gates_mncnh.components.hemoglobin import Hemoglobin, HemoglobinRiskEffect
 from vivarium_gates_mncnh.components.intervention import (
     AdditiveRiskEffect,
     CPAPAndACSRiskEffect,

--- a/src/vivarium_gates_mncnh/constants/data_values.py
+++ b/src/vivarium_gates_mncnh/constants/data_values.py
@@ -289,6 +289,7 @@ class __Pipelines(NamedTuple):
     MATERNAL_HEMORRHAGE_INCIDENCE_RISK = "maternal_hemorrhage.incidence_risk"
     IFA_SUPPLEMENTATION = "iron_folic_acid_supplementation.exposure"
     MMN_SUPPLEMENTATION = "multiple_micronutrient_supplementation.exposure"
+    IFA_DELETED_HEMOGLOBIN_EXPOSURE = "ifa_deleted_hemoglobin.exposure"
     HEMOGLOBIN_EXPOSURE = "hemoglobin.exposure"
 
 

--- a/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
@@ -5,12 +5,9 @@ plugins:
             builder_interface: vivarium_gates_mncnh.plugins.time.TimeInterface
 
 components:
-    vivarium_public_health:
-        risks:
-            - Risk('risk_factor.hemoglobin')
-
     vivarium_gates_mncnh:
         components:
+            - Hemoglobin()
             - AgelessPopulation("population.scaling_factor")
             - Pregnancy()
             - ResultsStratifier()


### PR DESCRIPTION
## Split up hemoglobin exposure and update oral iron effects

### Description
- *Category*: implementation
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6446
- *Research reference*: [hemoglobin pseudocode](https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_mncnh_portfolio/hemoglobin_component/module_document.html#pseudocode-implementation-summary)

### Changes and notes
Subclass Risk to create Hemoglobin class so that we have access to IFA-deleted exposure and final hemoglobin exposure.
Apply oral iron effects to IFA-deleted hemoglobin exposure.

### Verification and Testing
Ran simulation to completion.