### PR TITLE
model 18.1 - bugfixes

### DIFF
--- a/src/vivarium_gates_mncnh/components/intervention.py
+++ b/src/vivarium_gates_mncnh/components/intervention.py
@@ -237,7 +237,7 @@ class OralIronInterventionExposure(Component):
 
     def on_initialize_simulants(self, pop: SimulantData) -> None:
         pop_update = pd.DataFrame(
-            {COLUMNS.ORAL_IRON_INTERVENTION: "N/A"},
+            {COLUMNS.ORAL_IRON_INTERVENTION: "no_treatment"},
             index=pop.index,
         )
 

--- a/src/vivarium_gates_mncnh/components/intervention.py
+++ b/src/vivarium_gates_mncnh/components/intervention.py
@@ -7,6 +7,7 @@ import pandas as pd
 from layered_config_tree import ConfigurationError
 from vivarium import Component
 from vivarium.framework.engine import Builder
+from vivarium.framework.event import Event
 from vivarium.framework.lookup import LookupTable
 from vivarium.framework.population import SimulantData
 from vivarium.framework.randomness import RESIDUAL_CHOICE
@@ -21,6 +22,7 @@ from vivarium_gates_mncnh.constants.data_values import (
     INTERVENTIONS,
     PIPELINES,
     PREGNANCY_OUTCOMES,
+    SIMULATION_EVENT_NAMES,
 )
 from vivarium_gates_mncnh.constants.scenarios import INTERVENTION_SCENARIOS
 
@@ -196,12 +198,17 @@ class OralIronInterventionExposure(Component):
     }
 
     @property
+    def time_step_cleanup_priority(self) -> int:
+        # ANC attendance will have been updated
+        return 6
+
+    @property
     def columns_created(self) -> list[str]:
         return [COLUMNS.ORAL_IRON_INTERVENTION]
 
     @property
     def columns_required(self) -> list[str]:
-        return ["tracked"]
+        return [COLUMNS.ANC_ATTENDANCE]
 
     def __init__(self):
         super().__init__()
@@ -210,6 +217,7 @@ class OralIronInterventionExposure(Component):
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
+        self._sim_step_name = builder.time.simulation_event_name()
         self.clock = builder.time.clock()
         self.randomness = builder.randomness.get_stream(self.name)
 
@@ -228,17 +236,31 @@ class OralIronInterventionExposure(Component):
         )
 
     def on_initialize_simulants(self, pop: SimulantData) -> None:
+        pop_update = pd.DataFrame(
+            {COLUMNS.ORAL_IRON_INTERVENTION: "N/A"},
+            index=pop.index,
+        )
+
+        self.population_view.update(pop_update)
+
+    def on_time_step_cleanup(self, event: Event) -> None:
+        if self._sim_step_name() != SIMULATION_EVENT_NAMES.PREGNANCY:
+            return
+        pop = self.population_view.get(event.index)
+        attends_anc = pop[COLUMNS.ANC_ATTENDANCE] != ANC_ATTENDANCE_TYPES.NONE
+        anc_pop = pop.loc[attends_anc]
+
         if (
             INTERVENTION_SCENARIOS[self.scenario].ifa_mms_coverage
             == models.ORAL_IRON_INTERVENTION.MMS
         ):
             pop_update = pd.DataFrame(
                 {COLUMNS.ORAL_IRON_INTERVENTION: models.ORAL_IRON_INTERVENTION.MMS},
-                index=pop.index,
+                index=anc_pop.index,
             )
         else:
             pop_update = self.randomness.choice(
-                pop.index,
+                anc_pop.index,
                 choices=[
                     models.ORAL_IRON_INTERVENTION.IFA,
                     models.ORAL_IRON_INTERVENTION.NO_TREATMENT,

--- a/src/vivarium_gates_mncnh/components/observers.py
+++ b/src/vivarium_gates_mncnh/components/observers.py
@@ -165,13 +165,15 @@ class ResultsStratifier(ResultsStratifier_):
         )
         builder.results.register_stratification(
             "ifa_coverage",
-            [IFA_SUPPLEMENTATION.CAT1, IFA_SUPPLEMENTATION.CAT2],
+            ["covered", "uncovered"],
+            mapper=self.map_oral_iron_coverage,
             is_vectorized=True,
             requires_values=[PIPELINES.IFA_SUPPLEMENTATION],
         )
         builder.results.register_stratification(
             "mms_coverage",
-            [MMN_SUPPLEMENTATION.CAT1, MMN_SUPPLEMENTATION.CAT2],
+            ["covered", "uncovered"],
+            mapper=self.map_oral_iron_coverage,
             is_vectorized=True,
             requires_values=[PIPELINES.MMN_SUPPLEMENTATION],
         )
@@ -237,6 +239,9 @@ class ResultsStratifier(ResultsStratifier_):
             np.where(exposure < LOW_HEMOGLOBIN_THRESHOLD, "low", "adequate"),
             index=exposure.index,
         )
+
+    def map_oral_iron_coverage(self, pop: pd.DataFrame) -> pd.Series:
+        return pop.squeeze().replace({"cat1": "uncovered", "cat2": "covered"})
 
 
 class PAFResultsStratifier(ResultsStratifier_):

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -1100,7 +1100,7 @@ def load_risk_specific_shift(
 
     if key.name == "multiple_micronutrient_supplementation":
         excess_shift = get_data(key_group.EXCESS_SHIFT, location)
-        single_cat_shift = excess_shift.query("parameter=='cat1'").droplevel("parameter")
+        single_cat_shift = excess_shift.query("parameter=='cat2'").droplevel("parameter")
         risk_specific_shift = pd.DataFrame(
             0.0, columns=single_cat_shift.columns, index=single_cat_shift.index
         )

--- a/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
@@ -66,7 +66,7 @@ components:
 configuration:
     input_data:
         input_draw_number: 0
-        artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/model18.0/ethiopia.hdf"
+        artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/model18.1/ethiopia.hdf"
     interpolation:
         order: 0
         extrapolate: True

--- a/tests/test_lbwsg.py
+++ b/tests/test_lbwsg.py
@@ -14,8 +14,6 @@ from vivarium_gates_mncnh.constants.data_values import (
 
 from .utilities import get_interactive_context_state
 
-pytestmark = pytest.mark.skip(reason="Skipping this entire module for now")
-
 
 @pytest.fixture(scope="module")
 def birth_state(

--- a/tests/test_mortality.py
+++ b/tests/test_mortality.py
@@ -16,8 +16,6 @@ from vivarium_gates_mncnh.constants.data_values import (
 
 from .utilities import get_births_and_deaths_idx, get_interactive_context_state
 
-pytestmark = pytest.mark.skip(reason="Skipping this entire module for now")
-
 
 @pytest.fixture(scope="module")
 def late_neonatal_mortality_state(

--- a/tests/test_pregnancy.py
+++ b/tests/test_pregnancy.py
@@ -13,8 +13,6 @@ from vivarium_gates_mncnh.constants.data_values import (
 
 from .utilities import get_interactive_context_state
 
-pytestmark = pytest.mark.skip(reason="Skipping this entire module for now")
-
 
 @pytest.fixture(scope="module")
 def pregnancy_state(


### PR DESCRIPTION
## model 18.1 - bugfixes

### Description
- *Category*: bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6456

### Changes and notes
Only apply iron intervention to those who have ANC.
Update artifact so that exposed in oral iron intervention data is cat2. 
Update observer to output covered and uncovered instead of cat1 and cat2.
Expand anemia severity draws.  

### Verification and Testing
Rebuilt artifact and ran simulation. Got child jobs to complete that were previously failing because of missing draws in anemia severity (with final steps in psimulate still failing). 

*** REMINDER ***
CI WILL NOT RUN ANY TESTS.
MANUALLY RUN TESTS WITH EACH PR.
-->
- [X] all tests pass (`pytest --runslow`)