### PR TITLE
properly skip jenkins tests even with runslow

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,18 +38,21 @@ def pytest_configure(config):
 
 
 def pytest_collection_modifyitems(config, items):
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    skip_jenkins = pytest.mark.skip(reason="skipping tests in jenkins")
+    is_on_jenkins = os.environ.get("JENKINS_URL")
+
+    for item in items:
+        if is_on_jenkins:
+            item.add_marker(skip_jenkins)
+
     if config.getoption("--runslow"):
         # --runslow given in cli: do not skip slow tests
         return
-    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+
     for item in items:
         if "slow" in item.keywords:
             item.add_marker(skip_slow)
-
-    skip_jenkins = pytest.mark.skip(reason="skipping tests in jenkins")
-    if os.environ.get("JENKINS_URL"):
-        for item in items:
-            item.add_marker(skip_jenkins)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## properly skip jenkins tests even with runslow

### Changes and notes
Move runslow cli check return to occur after Jenkins check/marking. 

### Verification and Testing
Set dummy environment variable FOO to stand in for JENKINS_URL check. Ran pytest and pytest --runslow and checked that all test were skipped.
Removed dummy environment variable and checked that both pytest and pytest --runslow ran tests.