### PR TITLE
postpartum hemoglobin implementation

### DIFF
--- a/src/vivarium_gates_mncnh/components/__init__.py
+++ b/src/vivarium_gates_mncnh/components/__init__.py
@@ -24,7 +24,9 @@ from vivarium_gates_mncnh.components.lbwsg import (
 )
 from vivarium_gates_mncnh.components.maternal_disorders import (
     AbortionMiscarriageEctopicPregnancy,
+    HemorrhageEffectsOnHemoglobin,
     MaternalDisorder,
+    MaternalHemorrhage,
     PostpartumDepression,
     ResidualMaternalDisorders,
 )

--- a/src/vivarium_gates_mncnh/components/maternal_disorders.py
+++ b/src/vivarium_gates_mncnh/components/maternal_disorders.py
@@ -157,7 +157,7 @@ class MaternalHemorrhage(MaternalDisorder):
             p=[self.moderate_severity_probability, 1 - self.moderate_severity_probability],
             additional_key="hemorrhage_severity_choice",
         )
-        
+
         pop.loc[got_hemorrhage_index, self.maternal_disorder] = True
         pop.loc[got_hemorrhage_index, self.severity_column] = hemorrhage_severity
         self.population_view.update(pop)

--- a/src/vivarium_gates_mncnh/components/screening.py
+++ b/src/vivarium_gates_mncnh/components/screening.py
@@ -84,7 +84,7 @@ class AnemiaScreening(Component):
 
         # determine anemia status during pregnancy
         hemoglobin = self.hemoglobin(later_anc_pop.index)
-        later_anc_pop.loc[:, COLUMNS.ANEMIA_STATUS_DURING_PREGNANCY] = (
+        pop.loc[later_anc_pop.index, COLUMNS.ANEMIA_STATUS_DURING_PREGNANCY] = (
             pd.cut(
                 hemoglobin,
                 bins=[-np.inf] + ANEMIA_THRESHOLDS,
@@ -94,7 +94,10 @@ class AnemiaScreening(Component):
             .astype("object")
             .fillna("not_anemic")
         )
-        self.population_view.update(later_anc_pop)
+        pop[COLUMNS.ANEMIA_STATUS_DURING_PREGNANCY] = pop[
+            COLUMNS.ANEMIA_STATUS_DURING_PREGNANCY
+        ].fillna("not_tested")
+        self.population_view.update(pop)
 
         # determine who gets hemoglobin screening
         if INTERVENTION_SCENARIOS[self.scenario].hemoglobin_screening_coverage == "baseline":

--- a/src/vivarium_gates_mncnh/constants/data_values.py
+++ b/src/vivarium_gates_mncnh/constants/data_values.py
@@ -104,6 +104,14 @@ class __HemoglobinTestResults(NamedTuple):
 HEMOGLOBIN_TEST_RESULTS = __HemoglobinTestResults()
 
 
+class __MaternalHemorrhageSeverity(NamedTuple):
+    MODERATE: str = "moderate"
+    SEVERE: str = "severe"
+
+
+MATERNAL_HEMORRHAGE_SEVERITY = __MaternalHemorrhageSeverity()
+
+
 class __ANCRates(NamedTuple):
     RECEIVED_ULTRASOUND = {
         # https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_mncnh_portfolio/ai_ultrasound_module/module_document.html#id7
@@ -160,6 +168,7 @@ class __Columns(NamedTuple):
     STATED_GESTATIONAL_AGE = "stated_gestational_age"
     MATERNAL_SEPSIS = "maternal_sepsis_and_other_maternal_infections"
     MATERNAL_HEMORRHAGE = "maternal_hemorrhage"
+    MATERNAL_HEMORRHAGE_SEVERITY = "maternal_hemorrhage_severity"
     ABORTION_MISCARRIAGE_ECTOPIC_PREGNANCY = "abortion_miscarriage_ectopic_pregnancy"
     OBSTRUCTED_LABOR = "maternal_obstructed_labor_and_uterine_rupture"
     RESIDUAL_MATERNAL_DISORDERS = "residual_maternal_disorders"
@@ -513,6 +522,8 @@ MATERNAL_HEMORRHAGE_MODERATE_SEVERITY_PROBABILITY = get_truncnorm(
     lower_clip=0.0,
     upper_clip=1.0,
 )
+MODERATE_HEMORRHAGE_HEMOGLOBIN_SCALING_FACTOR = 0.9
+SEVERE_HEMORRHAGE_HEMOGLOBIN_SCALING_FACTOR = 0.83
 
 
 RESIDUAL_MATERNAL_DISORDER_CAUSE_NAMES = [

--- a/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
@@ -15,8 +15,8 @@ components:
             - ANCAttendance()
             - Ultrasound()
             - MaternalDisorder("maternal_obstructed_labor_and_uterine_rupture")
-            - MaternalDisorder("maternal_hemorrhage")
             - MaternalDisorder("maternal_sepsis_and_other_maternal_infections")
+            - MaternalHemorrhage()
             - ResidualMaternalDisorders()
             - AbortionMiscarriageEctopicPregnancy()
             - MaternalDisordersBurden()
@@ -44,6 +44,7 @@ components:
             - OralIronEffectsOnGestationalAge()
             - IVIronExposure()
             - IVIronEffectOnHemoglobin()
+            - HemorrhageEffectsOnHemoglobin()
             - DeliveryFacility()
             - InterventionAccess('cpap')
             - InterventionAccess('antibiotics')
@@ -76,7 +77,7 @@ components:
 configuration:
     input_data:
         input_draw_number: 60
-        artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/model25.0/ethiopia.hdf"
+        artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/postpartum_hemoglobin/ethiopia.hdf"
     interpolation:
         order: 0
         extrapolate: True


### PR DESCRIPTION
## postpartum hemoglobin implementation

### Description
- *Category*: feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6741
- *Research reference*: [postpartum hemoglobin](https://vivarium-research.readthedocs.io/en/latest/models/risk_effects/maternal_hemorrhage/index.html#postpartum-hemoglobin)

### Changes and notes
Assign moderate and severe severities to hemorrhage cases.
Update hemoglobin exposure based on hemorrhage after it has been assigned.
Update anemia status during pregnancy to appear in the state table correctly (simulation behavior should remain unchanged because it was only being used as a parameter in ferritin testing and the state table would have been correct at the time of the call) 

### Verification and Testing
Checked that ratio of postpartum to partum hemoglobin was what is expected based on hemorrhage severity.

<img width="782" height="387" alt="postpartum_hemoglobin_by_hemorrhage" src="https://github.com/user-attachments/assets/133a10bc-dccd-4caa-9d96-eb7b3e66852f" />

*** REMINDER ***
CI WILL NOT RUN ANY TESTS.
MANUALLY RUN TESTS WITH EACH PR.
-->
- [X] all tests pass (`pytest --runslow`) (with exception of the model 26 interactive hemoglobin notebook)