### PR TITLE
Pin upper bounds on packages migrating to the vivarium-suite monorepo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,10 +42,11 @@ if __name__ == "__main__":
         long_description = f.read()
 
     install_requirements = [
+        "vivarium_dependencies<2.0.0",
         "vivarium_dependencies[pandas,numpy,scipy,click,tables,loguru]",
         "vivarium_build_utils>=2.0.1,<3.0.0",
-        "gbd_mapping>=5.0.0",
-        "layered_config_tree",
+        "gbd_mapping>=5.0.0,<6.0.0",
+        "layered_config_tree<5.0.0",
         "vivarium>=4.0.0, <4.1.0",
         "vivarium_public_health>=5.0.0, <5.1.0",
         "click",
@@ -57,14 +58,14 @@ if __name__ == "__main__":
     setup_requires = ["setuptools_scm"]
 
     data_requirements = ["vivarium_inputs>=7.1.4"]
-    cluster_requirements = ["vivarium_cluster_tools>=2.0.0"]
+    cluster_requirements = ["vivarium_cluster_tools>=2.0.0,<4.0.0"]
     test_requirements = [
         "vivarium_dependencies[pytest]",
         "papermill",
         "jupyterlab",
-        "vivarium_testing_utils>=0.5.0",
+        "vivarium_testing_utils>=0.5.0,<0.6.0",
     ]
-    validation_requirements = ["vivarium_testing_utils[validation]"]
+    validation_requirements = ["vivarium_testing_utils[validation]<0.6.0"]
     lint_requirements = [
         "vivarium_dependencies[lint]",
     ]


### PR DESCRIPTION
## Pin upper bounds on packages migrating to the vivarium-suite monorepo

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, data artifact, implementation, observers,
                   post-processing, refactor, revert, test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-7016
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

<--
*** REMINDER ***
CI WILL NOT RUN ANY TESTS.
MANUALLY RUN TESTS WITH EACH PR.
MAKE SURE CONSTANTS/PATHS.PY IS USING THE CORRECT MODEL RESULTS DIRECTORY.
-->
- [ ] model results directory is up to date
- [ ] all tests pass (`pytest --runslow` with both *vivarium_gates_mncnh_artifact* and *vivarium_gates_mncnh_simulation*)

### Next steps

- [ ] Merge this pull request
- [ ] THIS IS A SENSITIVITY ANALYSIS/EXPERIMENT -- DO NOT MERGE!
