### PR TITLE
PPH/APH observers

### DIFF
--- a/src/vivarium_gates_mncnh/components/observers.py
+++ b/src/vivarium_gates_mncnh/components/observers.py
@@ -20,6 +20,7 @@ from vivarium_gates_mncnh.constants.data_keys import (
 from vivarium_gates_mncnh.constants.data_values import (
     ANC_ATTENDANCE_TYPES,
     ANEMIA_THRESHOLDS,
+    ANEMIA_THRESHOLDS_NON_PREGNANCY,
     CAUSES_OF_NEONATAL_MORTALITY,
     COLUMNS,
     DAYS_PER_WEEK,
@@ -44,12 +45,16 @@ from vivarium_gates_mncnh.constants.metadata import (
 from vivarium_gates_mncnh.utilities import get_child_age_bins
 
 
-def get_anemia_status_from_hemoglobin(hemoglobin: pd.Series) -> pd.Series:
+def get_anemia_status_from_hemoglobin(
+    hemoglobin: pd.Series, thresholds: list[float] | None = None
+) -> pd.Series:
     """Use anemia thresholds to determine anemia status."""
+    if thresholds is None:
+        thresholds = ANEMIA_THRESHOLDS
     anemia_status = (
         pd.cut(
             hemoglobin,
-            bins=[-np.inf] + ANEMIA_THRESHOLDS,
+            bins=[-np.inf] + thresholds,
             labels=["severe", "moderate", "mild"],
             right=False,
         )
@@ -593,13 +598,26 @@ class NeonatalBurdenObserver(BurdenObserver):
 
 
 class AnemiaYLDsObserver(PublicHealthObserver):
+    TIMESTEP_CATEGORIES = [
+        SIMULATION_EVENT_NAMES.FIRST_TRIMESTER_ANC,
+        SIMULATION_EVENT_NAMES.LATER_PREGNANCY_VISIT_TIMING,
+        SIMULATION_EVENT_NAMES.ULTRASOUND,
+        SIMULATION_EVENT_NAMES.EARLY_NEONATAL_MORTALITY,
+        SIMULATION_EVENT_NAMES.POSTPARTUM_HEMOGLOBIN_NINE_MONTH,
+    ]
+
     @property
     def configuration_defaults(self) -> dict[str, Any]:
         return {
             "stratification": {
                 self.get_configuration_name(): {
                     "exclude": [],
-                    "include": ["age_group", "anemia_status", "pregnancy_outcome"],
+                    "include": [
+                        "age_group",
+                        "anemia_status",
+                        "pregnancy_outcome",
+                        "timestep",
+                    ],
                 },
             },
         }
@@ -608,6 +626,13 @@ class AnemiaYLDsObserver(PublicHealthObserver):
         self._sim_step_name = builder.time.simulation_event_name()
         self.hemoglobin_name = PIPELINES.HEMOGLOBIN_EXPOSURE
         self.gestational_age_name = COLUMNS.GESTATIONAL_AGE_EXPOSURE
+        builder.results.register_stratification(
+            "timestep",
+            self.TIMESTEP_CATEGORIES,
+            mapper=self._map_timestep,
+            is_vectorized=True,
+            requires_attributes=["age"],
+        )
 
     def register_observations(self, builder: Builder) -> None:
         self.register_adding_observation(
@@ -651,6 +676,7 @@ class AnemiaYLDsObserver(PublicHealthObserver):
             SIMULATION_EVENT_NAMES.LATER_PREGNANCY_VISIT_TIMING,
             SIMULATION_EVENT_NAMES.ULTRASOUND,
             SIMULATION_EVENT_NAMES.EARLY_NEONATAL_MORTALITY,
+            SIMULATION_EVENT_NAMES.POSTPARTUM_HEMOGLOBIN_NINE_MONTH,
         ]
 
     def calculate_anemia_ylds(self, data: pd.DataFrame) -> float:
@@ -665,9 +691,17 @@ class AnemiaYLDsObserver(PublicHealthObserver):
         defined for live births and stillbirths by that point. This gestational
         age exposure will be modified by any iron interventions received at a
         first trimester ANC visit.
+
+        For the 6w-9m postpartum period, non-pregnancy-specific anemia
+        thresholds are used to determine disability weights.
         """
+        # Use non-pregnancy thresholds for the 6w-9m postpartum period
+        if self._sim_step_name() == SIMULATION_EVENT_NAMES.POSTPARTUM_HEMOGLOBIN_NINE_MONTH:
+            thresholds = ANEMIA_THRESHOLDS_NON_PREGNANCY
+        else:
+            thresholds = ANEMIA_THRESHOLDS
         anemia_status = get_anemia_status_from_hemoglobin(
-            self.population_view.get(data.index, self.hemoglobin_name)
+            self.population_view.get(data.index, self.hemoglobin_name), thresholds
         )
         dw = self.get_disability_weight_from_anemia_status(anemia_status)
         duration_years = self._get_duration_years(data)
@@ -695,6 +729,9 @@ class AnemiaYLDsObserver(PublicHealthObserver):
             SIMULATION_EVENT_NAMES.EARLY_NEONATAL_MORTALITY: lambda df: pd.Series(
                 6 * DAYS_PER_WEEK / DAYS_PER_YEAR, index=df.index
             ),  # 6 weeks in years
+            SIMULATION_EVENT_NAMES.POSTPARTUM_HEMOGLOBIN_NINE_MONTH: lambda df: pd.Series(
+                34 * DAYS_PER_WEEK / DAYS_PER_YEAR, index=df.index
+            ),  # 34 weeks (9 months - 6 weeks) in years
         }
         return duration_calculators[self._sim_step_name()](data)
 
@@ -741,6 +778,9 @@ class AnemiaYLDsObserver(PublicHealthObserver):
             "not_anemic": 0.0,
         }
         return anemia_status.map(anemia_status_to_dw)
+
+    def _map_timestep(self, pop: pd.DataFrame) -> pd.Series:
+        return pd.Series(self._sim_step_name(), index=pop.index)
 
 
 class NeonatalCauseRelativeRiskObserver(PublicHealthObserver):

--- a/src/vivarium_gates_mncnh/components/observers.py
+++ b/src/vivarium_gates_mncnh/components/observers.py
@@ -26,12 +26,14 @@ from vivarium_gates_mncnh.constants.data_values import (
     DAYS_PER_WEEK,
     DAYS_PER_YEAR,
     DELIVERY_FACILITY_TYPES,
+    EARLY_NEONATAL_DURATION_WEEKS,
     HEMORRHAGE_CAUSES,
     HEMORRHAGE_SEVERITY,
     INTERVENTIONS,
     LOW_HEMOGLOBIN_THRESHOLD,
     MATERNAL_DISORDERS,
     PIPELINES,
+    POSTPARTUM_NINE_MONTH_DURATION_WEEKS,
     PREGNANCY_OUTCOMES,
     SIMULATION_EVENT_NAMES,
     TIME_OF_FIRST_ANC_VISIT_PLACEHOLDER,
@@ -48,7 +50,27 @@ from vivarium_gates_mncnh.utilities import get_child_age_bins
 def get_anemia_status_from_hemoglobin(
     hemoglobin: pd.Series, thresholds: list[float] | None = None
 ) -> pd.Series:
-    """Use anemia thresholds to determine anemia status."""
+    """Determine anemia status from hemoglobin values using severity thresholds.
+
+    Bins hemoglobin values into anemia severity categories using ``pd.cut``
+    with left-closed intervals (``right=False``). Values at or above the highest
+    threshold are classified as "not_anemic".
+
+    Parameters
+    ----------
+    hemoglobin
+        Hemoglobin concentration values in g/L.
+    thresholds
+        Ascending list of three threshold values (g/L) defining the boundaries
+        between severe, moderate, and mild anemia. If None, uses the default
+        pregnancy-specific thresholds.
+
+    Returns
+    -------
+    pd.Series
+        Anemia status for each simulant, one of "severe", "moderate", "mild",
+        or "not_anemic".
+    """
     if thresholds is None:
         thresholds = ANEMIA_THRESHOLDS
     anemia_status = (
@@ -74,6 +96,7 @@ class ResultsStratifier(ResultsStratifier_):
             DELIVERY_FACILITY_TYPES.CEmONC,
             DELIVERY_FACILITY_TYPES.NONE,
         ]
+        self._sim_step_name = builder.time.simulation_event_name()
         self.register_stratifications(builder)
 
     def register_stratifications(self, builder: Builder) -> None:
@@ -298,7 +321,18 @@ class ResultsStratifier(ResultsStratifier_):
         return oral_iron_coverage
 
     def map_anemia_status(self, pop: pd.DataFrame) -> pd.Series:
-        return get_anemia_status_from_hemoglobin(pop[PIPELINES.HEMOGLOBIN_EXPOSURE])
+        """Map hemoglobin values to anemia status categories.
+
+        Use non-pregnancy thresholds during the postpartum nine-month step
+        to match the thresholds used in disability weight calculations.
+        """
+        if self._sim_step_name() == SIMULATION_EVENT_NAMES.POSTPARTUM_HEMOGLOBIN_NINE_MONTH:
+            thresholds = ANEMIA_THRESHOLDS_NON_PREGNANCY
+        else:
+            thresholds = None
+        return get_anemia_status_from_hemoglobin(
+            pop[PIPELINES.HEMOGLOBIN_EXPOSURE], thresholds
+        )
 
 
 class PAFResultsStratifier(ResultsStratifier_):
@@ -631,13 +665,14 @@ class AnemiaYLDsObserver(PublicHealthObserver):
             self.TIMESTEP_CATEGORIES,
             mapper=self._map_timestep,
             is_vectorized=True,
+            # requires_attributes cannot be empty; "age" is used as a placeholder
+            # to satisfy the framework requirement for a population DataFrame column.
             requires_attributes=["age"],
         )
 
     def register_observations(self, builder: Builder) -> None:
-        self.register_adding_observation(
+        shared_kwargs = dict(
             builder=builder,
-            name="anemia_ylds",
             when="time_step__prepare",
             pop_filter="is_alive == True",
             requires_attributes=[
@@ -650,34 +685,20 @@ class AnemiaYLDsObserver(PublicHealthObserver):
             additional_stratifications=self.configuration.include,
             excluded_stratifications=self.configuration.exclude,
             to_observe=self.to_observe,
+        )
+        self.register_adding_observation(
+            **shared_kwargs,
+            name="anemia_ylds",
             aggregator=self.calculate_anemia_ylds,
         )
         self.register_adding_observation(
-            builder=builder,
+            **shared_kwargs,
             name="anemia_person_time",
-            when="time_step__prepare",
-            pop_filter="is_alive == True",
-            requires_attributes=[
-                COLUMNS.TIME_OF_FIRST_ANC_VISIT,
-                COLUMNS.TIME_OF_LATER_ANC_VISIT,
-                COLUMNS.ANC_ATTENDANCE,
-                PIPELINES.HEMOGLOBIN_EXPOSURE,
-                COLUMNS.GESTATIONAL_AGE_EXPOSURE,
-            ],
-            additional_stratifications=self.configuration.include,
-            excluded_stratifications=self.configuration.exclude,
-            to_observe=self.to_observe,
             aggregator=self.calculate_anemia_person_time,
         )
 
     def to_observe(self, event: Event) -> bool:
-        return self._sim_step_name() in [
-            SIMULATION_EVENT_NAMES.FIRST_TRIMESTER_ANC,
-            SIMULATION_EVENT_NAMES.LATER_PREGNANCY_VISIT_TIMING,
-            SIMULATION_EVENT_NAMES.ULTRASOUND,
-            SIMULATION_EVENT_NAMES.EARLY_NEONATAL_MORTALITY,
-            SIMULATION_EVENT_NAMES.POSTPARTUM_HEMOGLOBIN_NINE_MONTH,
-        ]
+        return self._sim_step_name() in self.TIMESTEP_CATEGORIES
 
     def calculate_anemia_ylds(self, data: pd.DataFrame) -> float:
         """Calculate YLDs for anemia based on the current simulation event.
@@ -695,7 +716,9 @@ class AnemiaYLDsObserver(PublicHealthObserver):
         For the 6w-9m postpartum period, non-pregnancy-specific anemia
         thresholds are used to determine disability weights.
         """
-        # Use non-pregnancy thresholds for the 6w-9m postpartum period
+        # Use non-pregnancy thresholds for the 6w-9m postpartum period.
+        # The same disability weights are used regardless of threshold set - only the
+        # anemia status categorization changes between pregnancy and non-pregnancy periods.
         if self._sim_step_name() == SIMULATION_EVENT_NAMES.POSTPARTUM_HEMOGLOBIN_NINE_MONTH:
             thresholds = ANEMIA_THRESHOLDS_NON_PREGNANCY
         else:
@@ -727,11 +750,12 @@ class AnemiaYLDsObserver(PublicHealthObserver):
             SIMULATION_EVENT_NAMES.LATER_PREGNANCY_VISIT_TIMING: self._get_later_anc_interval,
             SIMULATION_EVENT_NAMES.ULTRASOUND: self._get_later_anc_to_delivery_interval,
             SIMULATION_EVENT_NAMES.EARLY_NEONATAL_MORTALITY: lambda df: pd.Series(
-                6 * DAYS_PER_WEEK / DAYS_PER_YEAR, index=df.index
-            ),  # 6 weeks in years
+                EARLY_NEONATAL_DURATION_WEEKS * DAYS_PER_WEEK / DAYS_PER_YEAR, index=df.index
+            ),
             SIMULATION_EVENT_NAMES.POSTPARTUM_HEMOGLOBIN_NINE_MONTH: lambda df: pd.Series(
-                34 * DAYS_PER_WEEK / DAYS_PER_YEAR, index=df.index
-            ),  # 34 weeks (9 months - 6 weeks) in years
+                POSTPARTUM_NINE_MONTH_DURATION_WEEKS * DAYS_PER_WEEK / DAYS_PER_YEAR,
+                index=df.index,
+            ),
         }
         return duration_calculators[self._sim_step_name()](data)
 
@@ -780,6 +804,7 @@ class AnemiaYLDsObserver(PublicHealthObserver):
         return anemia_status.map(anemia_status_to_dw)
 
     def _map_timestep(self, pop: pd.DataFrame) -> pd.Series:
+        """Map all simulants to the current simulation event name for stratification."""
         return pd.Series(self._sim_step_name(), index=pop.index)
 
 

--- a/src/vivarium_gates_mncnh/constants/data_values.py
+++ b/src/vivarium_gates_mncnh/constants/data_values.py
@@ -24,6 +24,10 @@ DAYS_PER_YEAR = 365.25
 DAYS_PER_WEEK = 7
 MONTHS_PER_YEAR = 12
 
+# Duration constants for anemia YLD calculations
+EARLY_NEONATAL_DURATION_WEEKS = 6
+POSTPARTUM_NINE_MONTH_DURATION_WEEKS = 34  # 40 weeks (full term) - 6 weeks postpartum
+
 # GBD sequela IDs for maternal hemorrhage severity splits
 MODERATE_HEMORRHAGE_SEQUELA_ID = 180
 SEVERE_HEMORRHAGE_SEQUELA_ID = 181
@@ -541,8 +545,8 @@ HEMOGLOBIN_TEST_SENSITIVITY = 0.85  # low hemoglobin that tests low
 HEMOGLOBIN_TEST_SPECIFICITY = 0.8  # adequate hemoglobin that tests adequate
 LOW_HEMOGLOBIN_THRESHOLD = 100
 
-ANEMIA_THRESHOLDS = [70, 100, 110]  # ordering is severe, moderate, mild
-ANEMIA_THRESHOLDS_NON_PREGNANCY = [80, 110, 120]  # ordering is severe, moderate, mild
+ANEMIA_THRESHOLDS = [70, 100, 110]  # g/L, ascending: severe < moderate < mild
+ANEMIA_THRESHOLDS_NON_PREGNANCY = [80, 110, 120]  # g/L, ascending: severe < moderate < mild
 
 RESIDUAL_MATERNAL_DISORDER_CAUSE_NAMES = [
     "maternal_hypertensive_disorders",  # 369

--- a/src/vivarium_gates_mncnh/constants/data_values.py
+++ b/src/vivarium_gates_mncnh/constants/data_values.py
@@ -542,6 +542,7 @@ HEMOGLOBIN_TEST_SPECIFICITY = 0.8  # adequate hemoglobin that tests adequate
 LOW_HEMOGLOBIN_THRESHOLD = 100
 
 ANEMIA_THRESHOLDS = [70, 100, 110]  # ordering is severe, moderate, mild
+ANEMIA_THRESHOLDS_NON_PREGNANCY = [80, 110, 120]  # ordering is severe, moderate, mild
 
 RESIDUAL_MATERNAL_DISORDER_CAUSE_NAMES = [
     "maternal_hypertensive_disorders",  # 369

--- a/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
@@ -121,7 +121,7 @@ configuration:
             - 'postpartum_depression'
 
     population:
-        population_size: 200_000
+        population_size: 20_000
         initialization_age_min: 10
         initialization_age_max: 54
         include_sex: "Female"

--- a/tests/model_notebooks/interactive/executed/branch_smoke_checks_aph_pph.ipynb
+++ b/tests/model_notebooks/interactive/executed/branch_smoke_checks_aph_pph.ipynb
@@ -5,10 +5,10 @@
    "id": "75f12b55",
    "metadata": {
     "papermill": {
-     "duration": 0.010913,
-     "end_time": "2026-05-20T16:13:08.429757+00:00",
+     "duration": 0.010853,
+     "end_time": "2026-05-20T18:08:43.207129+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:13:08.418844+00:00",
+     "start_time": "2026-05-20T18:08:43.196276+00:00",
      "status": "completed"
     },
     "tags": []
@@ -34,16 +34,16 @@
    "id": "a45239fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:13:08.444982Z",
-     "iopub.status.busy": "2026-05-20T16:13:08.444373Z",
-     "iopub.status.idle": "2026-05-20T16:13:10.347151Z",
-     "shell.execute_reply": "2026-05-20T16:13:10.345609Z"
+     "iopub.execute_input": "2026-05-20T18:08:43.221144Z",
+     "iopub.status.busy": "2026-05-20T18:08:43.220931Z",
+     "iopub.status.idle": "2026-05-20T18:08:47.247964Z",
+     "shell.execute_reply": "2026-05-20T18:08:47.246604Z"
     },
     "papermill": {
-     "duration": 1.911366,
-     "end_time": "2026-05-20T16:13:10.348001+00:00",
+     "duration": 4.035053,
+     "end_time": "2026-05-20T18:08:47.248865+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:13:08.436635+00:00",
+     "start_time": "2026-05-20T18:08:43.213812+00:00",
      "status": "completed"
     },
     "tags": []
@@ -78,16 +78,16 @@
    "id": "b7f5bc48",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:13:10.362788Z",
-     "iopub.status.busy": "2026-05-20T16:13:10.362371Z",
-     "iopub.status.idle": "2026-05-20T16:13:13.161285Z",
-     "shell.execute_reply": "2026-05-20T16:13:13.159690Z"
+     "iopub.execute_input": "2026-05-20T18:08:47.262080Z",
+     "iopub.status.busy": "2026-05-20T18:08:47.261759Z",
+     "iopub.status.idle": "2026-05-20T18:08:50.093690Z",
+     "shell.execute_reply": "2026-05-20T18:08:50.092229Z"
     },
     "papermill": {
-     "duration": 2.807098,
-     "end_time": "2026-05-20T16:13:13.162057+00:00",
+     "duration": 2.839429,
+     "end_time": "2026-05-20T18:08:50.094417+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:13:10.354959+00:00",
+     "start_time": "2026-05-20T18:08:47.254988+00:00",
      "status": "completed"
     },
     "tags": []
@@ -166,10 +166,10 @@
    "id": "3e2b43f4",
    "metadata": {
     "papermill": {
-     "duration": 0.005922,
-     "end_time": "2026-05-20T16:13:13.174775+00:00",
+     "duration": 0.00612,
+     "end_time": "2026-05-20T18:08:50.107094+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:13:13.168853+00:00",
+     "start_time": "2026-05-20T18:08:50.100974+00:00",
      "status": "completed"
     },
     "tags": []
@@ -184,16 +184,16 @@
    "id": "d0c3f9be",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:13:13.188026Z",
-     "iopub.status.busy": "2026-05-20T16:13:13.187787Z",
-     "iopub.status.idle": "2026-05-20T16:15:01.706499Z",
-     "shell.execute_reply": "2026-05-20T16:15:01.705187Z"
+     "iopub.execute_input": "2026-05-20T18:08:50.121922Z",
+     "iopub.status.busy": "2026-05-20T18:08:50.121722Z",
+     "iopub.status.idle": "2026-05-20T18:10:29.496606Z",
+     "shell.execute_reply": "2026-05-20T18:10:29.495374Z"
     },
     "papermill": {
-     "duration": 108.526875,
-     "end_time": "2026-05-20T16:15:01.707776+00:00",
+     "duration": 99.384402,
+     "end_time": "2026-05-20T18:10:29.497776+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:13:13.180901+00:00",
+     "start_time": "2026-05-20T18:08:50.113374+00:00",
      "status": "completed"
     },
     "tags": []
@@ -203,21 +203,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:13:13.315\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:08:50.366\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:13:13.316\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:08:50.367\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:13:13.316\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:08:50.368\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
      ]
     },
     {
@@ -262,133 +262,133 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:13:55.815\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:09:29.717\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:13:55.816\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:09:29.718\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:13:56.017\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:09:29.899\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:13:56.018\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:09:29.899\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:13:56.018\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:09:29.900\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:13:56.019\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:09:29.900\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:13:56.019\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:09:29.901\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:13:56.020\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:09:29.901\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:13:56.021\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:09:29.902\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:13:56.021\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:09:29.902\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:13:56.022\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:09:29.903\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:13:56.023\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:09:29.904\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:13:56.023\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:09:29.908\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:13:56.024\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:09:29.908\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:13:56.028\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:09:29.909\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:13:56.029\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:09:29.909\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:13:56.030\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:09:29.910\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:13:56.031\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
+      "\u001b[32m2026-05-20 11:09:29.911\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
       "['ferritin_screening_coverage', 'hemoglobin_screening_coverage', 'sex']\u001b[0m\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1c4dc2ca0a0c4e21bc67a0204aba9f42",
+       "model_id": "85025cbf309d4351b93ff60cdea2e507",
        "version_major": 2,
        "version_minor": 0
       },
@@ -403,126 +403,126 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:13:58.996\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:09:32.562\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:14:14.680\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:09:46.789\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:14:15.967\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:09:47.865\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:14:17.702\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:09:49.364\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:14:34.692\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:10:04.606\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:14:53.473\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:10:21.813\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:14:54.238\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:10:22.534\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:14:54.347\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:10:22.636\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:14:55.084\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:10:23.332\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:14:55.842\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:10:24.080\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:14:56.571\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:10:24.748\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:14:57.399\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:10:25.510\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:14:58.095\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:10:26.186\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:14:58.823\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:10:26.897\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:14:59.571\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:10:27.569\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:15:00.323\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:10:28.256\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:15:00.350\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:10:28.282\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:15:01.128\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:10:28.993\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -696,10 +696,10 @@
    "id": "3ab3f53c",
    "metadata": {
     "papermill": {
-     "duration": 0.009196,
-     "end_time": "2026-05-20T16:15:01.726252+00:00",
+     "duration": 0.008109,
+     "end_time": "2026-05-20T18:10:29.515096+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:15:01.717056+00:00",
+     "start_time": "2026-05-20T18:10:29.506987+00:00",
      "status": "completed"
     },
     "tags": []
@@ -714,16 +714,16 @@
    "id": "e181f0a6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:15:01.746347Z",
-     "iopub.status.busy": "2026-05-20T16:15:01.746060Z",
-     "iopub.status.idle": "2026-05-20T16:16:48.779904Z",
-     "shell.execute_reply": "2026-05-20T16:16:48.778463Z"
+     "iopub.execute_input": "2026-05-20T18:10:29.533561Z",
+     "iopub.status.busy": "2026-05-20T18:10:29.533276Z",
+     "iopub.status.idle": "2026-05-20T18:12:13.238111Z",
+     "shell.execute_reply": "2026-05-20T18:12:13.237200Z"
     },
     "papermill": {
-     "duration": 107.047253,
-     "end_time": "2026-05-20T16:16:48.783008+00:00",
+     "duration": 103.716674,
+     "end_time": "2026-05-20T18:12:13.240495+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:15:01.735755+00:00",
+     "start_time": "2026-05-20T18:10:29.523821+00:00",
      "status": "completed"
     },
     "tags": []
@@ -733,21 +733,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:15:01.761\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:10:29.547\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:15:01.762\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:10:29.548\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:15:01.763\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:10:29.548\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
      ]
     },
     {
@@ -777,7 +777,13 @@
      "output_type": "stream",
      "text": [
       "/ihme/homes/hjafari/miniconda3/envs/vivarium_gates_mncnh_simulation/lib/python3.11/site-packages/vivarium/framework/lookup/interpolation.py:72: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.\n",
-      "  sub_tables = list(self.data.groupby(list(self.categorical_parameters)))\n",
+      "  sub_tables = list(self.data.groupby(list(self.categorical_parameters)))\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
       "/ihme/homes/hjafari/miniconda3/envs/vivarium_gates_mncnh_simulation/lib/python3.11/site-packages/vivarium/framework/lookup/interpolation.py:72: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.\n",
       "  sub_tables = list(self.data.groupby(list(self.categorical_parameters)))\n"
      ]
@@ -786,133 +792,133 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:15:43.108\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:11:08.932\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:15:43.109\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:11:08.933\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:15:43.288\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:11:09.111\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:15:43.289\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:11:09.111\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:15:43.290\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:11:09.114\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:15:43.290\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:11:09.114\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:15:43.291\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:11:09.115\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:15:43.291\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:11:09.116\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:15:43.292\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:11:09.117\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:15:43.292\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:11:09.118\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:15:43.293\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:11:09.119\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:15:43.293\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:11:09.121\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:15:43.294\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:11:09.121\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:15:43.294\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:11:09.123\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:15:43.295\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:11:09.123\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:15:43.295\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:11:09.125\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:15:43.296\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:11:09.125\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:15:43.297\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
+      "\u001b[32m2026-05-20 11:11:09.127\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
       "['ferritin_screening_coverage', 'hemoglobin_screening_coverage', 'sex']\u001b[0m\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "124be4dbd6fb4ef2bc996a1cb555d874",
+       "model_id": "1853c68406774f5eae9839dfe2a247b5",
        "version_major": 2,
        "version_minor": 0
       },
@@ -927,161 +933,161 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:15:45.769\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:11:11.641\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:16:00.083\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:11:25.924\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:16:01.148\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:11:26.977\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:16:02.640\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:11:28.454\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:16:18.046\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:11:43.613\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:16:35.558\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:00.402\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:16:36.273\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:01.095\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:16:36.374\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:01.195\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:16:37.066\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:01.867\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:16:37.795\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:02.579\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:16:38.471\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:03.238\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:16:39.211\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:03.972\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:16:39.841\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:04.651\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:16:40.567\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:05.337\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:16:41.255\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:05.994\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:16:41.935\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:06.647\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:16:41.960\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:06.670\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:16:42.645\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:07.337\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:16:42.779\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-16 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:07.469\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-16 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:16:43.490\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:08.158\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:16:43.602\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-17 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:08.262\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-17 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:16:44.265\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-18 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:08.901\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-18 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:16:44.920\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-19 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:09.537\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-19 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -1127,10 +1133,10 @@
    "id": "bcd55204",
    "metadata": {
     "papermill": {
-     "duration": 0.011019,
-     "end_time": "2026-05-20T16:16:48.805355+00:00",
+     "duration": 0.010462,
+     "end_time": "2026-05-20T18:12:13.261548+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:16:48.794336+00:00",
+     "start_time": "2026-05-20T18:12:13.251086+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1145,16 +1151,16 @@
    "id": "4e074598",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:16:48.828470Z",
-     "iopub.status.busy": "2026-05-20T16:16:48.828196Z",
-     "iopub.status.idle": "2026-05-20T16:20:01.684170Z",
-     "shell.execute_reply": "2026-05-20T16:20:01.683116Z"
+     "iopub.execute_input": "2026-05-20T18:12:13.284051Z",
+     "iopub.status.busy": "2026-05-20T18:12:13.283800Z",
+     "iopub.status.idle": "2026-05-20T18:15:27.948519Z",
+     "shell.execute_reply": "2026-05-20T18:15:27.947389Z"
     },
     "papermill": {
-     "duration": 192.869077,
-     "end_time": "2026-05-20T16:20:01.685060+00:00",
+     "duration": 194.677598,
+     "end_time": "2026-05-20T18:15:27.949668+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:16:48.815983+00:00",
+     "start_time": "2026-05-20T18:12:13.272070+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1164,21 +1170,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:16:48.849\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:13.305\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:16:48.850\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:13.305\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:16:48.850\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:13.306\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
      ]
     },
     {
@@ -1217,133 +1223,133 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:17:28.685\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:52.386\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:17:28.686\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:52.387\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:17:28.874\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:52.577\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:17:28.874\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:52.578\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:17:28.875\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:52.578\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:17:28.876\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:52.579\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:17:28.876\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:52.579\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:17:28.877\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:52.580\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:17:28.877\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:52.580\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:17:28.878\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:52.581\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:17:28.879\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:52.581\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:17:28.879\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:52.582\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:17:28.880\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:52.582\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:17:28.881\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:52.583\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:17:28.881\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:52.583\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:17:28.882\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:52.584\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:17:28.882\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:52.589\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:17:28.883\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
+      "\u001b[32m2026-05-20 11:12:52.590\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
       "['ferritin_screening_coverage', 'hemoglobin_screening_coverage', 'sex']\u001b[0m\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0a9a50d7428d4157bb2c964f40e594a2",
+       "model_id": "4a83337a43014b9a90639c77282fdc3c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1358,147 +1364,147 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:17:31.309\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:12:54.980\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:17:44.874\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:13:08.505\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:17:45.910\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:13:09.539\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:17:47.356\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:13:10.993\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:18:02.309\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:13:25.908\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:18:19.190\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:13:42.982\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:18:19.891\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:13:43.697\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:18:19.991\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:13:43.798\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:18:20.655\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:13:44.480\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:18:21.327\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:13:45.186\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:18:21.968\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:13:45.844\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:18:22.691\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:13:46.608\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:18:23.327\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:13:47.274\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:18:24.008\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:13:47.968\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:18:24.652\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:13:48.638\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:18:25.316\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:13:49.305\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:18:25.341\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:13:49.329\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:18:26.012\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:13:50.011\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:18:26.166\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:13:50.170\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:18:26.167\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:13:50.171\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:18:26.167\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:13:50.171\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
      ]
     },
     {
@@ -1537,133 +1543,133 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:05.012\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:14:29.034\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:05.013\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:14:29.034\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:05.201\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:14:29.219\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:05.202\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:14:29.219\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:05.202\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:14:29.220\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:05.203\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:14:29.220\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:05.203\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:14:29.221\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:05.204\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:14:29.221\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:05.204\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:14:29.222\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:05.205\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:14:29.222\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:05.205\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:14:29.223\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:05.208\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:14:29.223\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:05.209\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:14:29.224\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:05.209\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:14:29.224\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:05.210\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:14:29.225\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:05.210\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:14:29.226\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:05.211\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:14:29.226\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:05.212\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
+      "\u001b[32m2026-05-20 11:14:29.227\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
       "['ferritin_screening_coverage', 'hemoglobin_screening_coverage', 'sex']\u001b[0m\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9bc0cb7251ca4faf85ebe7a2dec5a0c7",
+       "model_id": "38bf795a3e6649d3ad20d1e37a8fd65f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1678,126 +1684,126 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:07.711\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:14:31.809\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:21.023\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:14:45.536\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:22.018\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:14:46.600\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:23.400\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:14:48.064\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:38.455\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:15:03.446\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:55.050\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:15:20.901\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:55.713\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:15:21.612\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:55.811\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:15:21.715\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:56.453\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:15:22.385\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:57.100\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:15:23.073\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:57.721\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:15:23.728\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:58.407\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:15:24.455\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:58.996\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:15:25.083\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:19:59.641\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:15:25.765\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:00.254\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:15:26.410\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:00.869\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:15:27.088\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:00.894\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:15:27.114\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:01.531\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:15:27.786\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -1946,16 +1952,16 @@
    "id": "d94fd4fd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:20:01.717436Z",
-     "iopub.status.busy": "2026-05-20T16:20:01.717095Z",
-     "iopub.status.idle": "2026-05-20T16:20:01.731917Z",
-     "shell.execute_reply": "2026-05-20T16:20:01.730769Z"
+     "iopub.execute_input": "2026-05-20T18:15:27.982022Z",
+     "iopub.status.busy": "2026-05-20T18:15:27.981732Z",
+     "iopub.status.idle": "2026-05-20T18:15:27.999001Z",
+     "shell.execute_reply": "2026-05-20T18:15:27.997743Z"
     },
     "papermill": {
-     "duration": 0.031559,
-     "end_time": "2026-05-20T16:20:01.732644+00:00",
+     "duration": 0.034313,
+     "end_time": "2026-05-20T18:15:27.999864+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:20:01.701085+00:00",
+     "start_time": "2026-05-20T18:15:27.965551+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2036,10 +2042,10 @@
    "id": "f426e5db",
    "metadata": {
     "papermill": {
-     "duration": 0.01453,
-     "end_time": "2026-05-20T16:20:01.761917+00:00",
+     "duration": 0.014481,
+     "end_time": "2026-05-20T18:15:28.030622+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:20:01.747387+00:00",
+     "start_time": "2026-05-20T18:15:28.016141+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2056,16 +2062,16 @@
    "id": "07f027aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:20:01.792188Z",
-     "iopub.status.busy": "2026-05-20T16:20:01.791960Z",
-     "iopub.status.idle": "2026-05-20T16:20:01.828633Z",
-     "shell.execute_reply": "2026-05-20T16:20:01.827397Z"
+     "iopub.execute_input": "2026-05-20T18:15:28.061955Z",
+     "iopub.status.busy": "2026-05-20T18:15:28.061566Z",
+     "iopub.status.idle": "2026-05-20T18:15:28.102528Z",
+     "shell.execute_reply": "2026-05-20T18:15:28.101404Z"
     },
     "papermill": {
-     "duration": 0.052382,
-     "end_time": "2026-05-20T16:20:01.829325+00:00",
+     "duration": 0.058163,
+     "end_time": "2026-05-20T18:15:28.103572+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:20:01.776943+00:00",
+     "start_time": "2026-05-20T18:15:28.045409+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2177,10 +2183,10 @@
    "id": "4c744c2f",
    "metadata": {
     "papermill": {
-     "duration": 0.014836,
-     "end_time": "2026-05-20T16:20:01.859613+00:00",
+     "duration": 0.01633,
+     "end_time": "2026-05-20T18:15:28.137367+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:20:01.844777+00:00",
+     "start_time": "2026-05-20T18:15:28.121037+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2197,16 +2203,16 @@
    "id": "b2297d29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:20:01.893700Z",
-     "iopub.status.busy": "2026-05-20T16:20:01.893457Z",
-     "iopub.status.idle": "2026-05-20T16:20:02.032840Z",
-     "shell.execute_reply": "2026-05-20T16:20:02.031615Z"
+     "iopub.execute_input": "2026-05-20T18:15:28.169182Z",
+     "iopub.status.busy": "2026-05-20T18:15:28.168750Z",
+     "iopub.status.idle": "2026-05-20T18:15:28.314193Z",
+     "shell.execute_reply": "2026-05-20T18:15:28.313030Z"
     },
     "papermill": {
-     "duration": 0.157425,
-     "end_time": "2026-05-20T16:20:02.033563+00:00",
+     "duration": 0.162732,
+     "end_time": "2026-05-20T18:15:28.315276+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:20:01.876138+00:00",
+     "start_time": "2026-05-20T18:15:28.152544+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2254,10 +2260,10 @@
    "id": "7277cedc",
    "metadata": {
     "papermill": {
-     "duration": 0.014704,
-     "end_time": "2026-05-20T16:20:02.063753+00:00",
+     "duration": 0.015695,
+     "end_time": "2026-05-20T18:15:28.347963+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:20:02.049049+00:00",
+     "start_time": "2026-05-20T18:15:28.332268+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2276,16 +2282,16 @@
    "id": "448f9016",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:20:02.095666Z",
-     "iopub.status.busy": "2026-05-20T16:20:02.095485Z",
-     "iopub.status.idle": "2026-05-20T16:22:04.197666Z",
-     "shell.execute_reply": "2026-05-20T16:22:04.196613Z"
+     "iopub.execute_input": "2026-05-20T18:15:28.382524Z",
+     "iopub.status.busy": "2026-05-20T18:15:28.382237Z",
+     "iopub.status.idle": "2026-05-20T18:17:32.505994Z",
+     "shell.execute_reply": "2026-05-20T18:17:32.504763Z"
     },
     "papermill": {
-     "duration": 122.121538,
-     "end_time": "2026-05-20T16:22:04.199940+00:00",
+     "duration": 124.146155,
+     "end_time": "2026-05-20T18:17:32.510347+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:20:02.078402+00:00",
+     "start_time": "2026-05-20T18:15:28.364192+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2295,21 +2301,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:02.109\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:15:28.398\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:02.110\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:15:28.399\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:02.111\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:15:28.400\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
      ]
     },
     {
@@ -2327,14 +2333,6 @@
       "/ihme/homes/hjafari/miniconda3/envs/vivarium_gates_mncnh_simulation/lib/python3.11/site-packages/vivarium/framework/lookup/interpolation.py:72: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.\n",
       "  sub_tables = list(self.data.groupby(list(self.categorical_parameters)))\n",
       "/ihme/homes/hjafari/miniconda3/envs/vivarium_gates_mncnh_simulation/lib/python3.11/site-packages/vivarium/framework/lookup/interpolation.py:72: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.\n",
-      "  sub_tables = list(self.data.groupby(list(self.categorical_parameters)))\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/ihme/homes/hjafari/miniconda3/envs/vivarium_gates_mncnh_simulation/lib/python3.11/site-packages/vivarium/framework/lookup/interpolation.py:72: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.\n",
       "  sub_tables = list(self.data.groupby(list(self.categorical_parameters)))\n",
       "/ihme/homes/hjafari/miniconda3/envs/vivarium_gates_mncnh_simulation/lib/python3.11/site-packages/vivarium/framework/lookup/interpolation.py:72: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.\n",
       "  sub_tables = list(self.data.groupby(list(self.categorical_parameters)))\n",
@@ -2347,6 +2345,8 @@
      "output_type": "stream",
      "text": [
       "/ihme/homes/hjafari/miniconda3/envs/vivarium_gates_mncnh_simulation/lib/python3.11/site-packages/vivarium/framework/lookup/interpolation.py:72: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.\n",
+      "  sub_tables = list(self.data.groupby(list(self.categorical_parameters)))\n",
+      "/ihme/homes/hjafari/miniconda3/envs/vivarium_gates_mncnh_simulation/lib/python3.11/site-packages/vivarium/framework/lookup/interpolation.py:72: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.\n",
       "  sub_tables = list(self.data.groupby(list(self.categorical_parameters)))\n"
      ]
     },
@@ -2354,133 +2354,133 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:41.024\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:16:08.372\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:41.025\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:16:08.373\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:41.217\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:16:08.556\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:41.218\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:16:08.557\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:41.218\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:16:08.557\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:41.219\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:16:08.558\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:41.219\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:16:08.558\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:41.220\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:16:08.559\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:41.220\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:16:08.559\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:41.221\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:16:08.560\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:41.222\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:16:08.560\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:41.224\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:16:08.562\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:41.225\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:16:08.563\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:41.226\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:16:08.563\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:41.226\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:16:08.564\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:41.227\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:16:08.564\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:41.227\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:16:08.565\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:41.228\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
+      "\u001b[32m2026-05-20 11:16:08.566\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
       "['ferritin_screening_coverage', 'hemoglobin_screening_coverage', 'sex']\u001b[0m\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dc190b979f3940dc900d6c7cd367a05b",
+       "model_id": "86aacd80a00d46f9a3ffe74ee080357d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2495,168 +2495,168 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:43.579\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:16:10.934\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:57.040\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:16:24.481\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:58.059\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:16:25.484\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:20:59.445\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:16:26.890\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:21:14.547\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:16:42.362\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:21:31.254\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:16:59.292\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:21:31.919\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:16:59.960\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:21:32.018\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:17:00.057\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:21:32.655\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:17:00.697\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:21:33.308\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:17:01.356\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:21:33.917\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:17:01.964\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:21:34.606\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:17:02.655\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:21:35.212\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:17:03.264\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:21:35.859\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:17:03.911\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:21:36.469\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:17:04.538\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:21:37.086\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:17:05.165\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:21:37.110\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:17:05.188\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:21:37.748\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:17:05.824\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:21:37.880\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-16 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:17:05.954\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-16 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:21:38.515\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:17:06.593\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:21:38.621\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-17 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:17:06.696\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-17 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:21:39.220\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-18 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:17:07.307\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-18 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:21:39.827\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-19 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:17:07.911\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-19 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:21:43.477\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-20 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:17:11.601\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-20 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -2805,10 +2805,10 @@
    "id": "2b4100d8",
    "metadata": {
     "papermill": {
-     "duration": 0.018874,
-     "end_time": "2026-05-20T16:22:04.237589+00:00",
+     "duration": 0.017654,
+     "end_time": "2026-05-20T18:17:32.546004+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:22:04.218715+00:00",
+     "start_time": "2026-05-20T18:17:32.528350+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2828,16 +2828,16 @@
    "id": "7763ecdd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:22:04.273944Z",
-     "iopub.status.busy": "2026-05-20T16:22:04.273733Z",
-     "iopub.status.idle": "2026-05-20T16:22:36.488810Z",
-     "shell.execute_reply": "2026-05-20T16:22:36.487803Z"
+     "iopub.execute_input": "2026-05-20T18:17:32.583458Z",
+     "iopub.status.busy": "2026-05-20T18:17:32.583235Z",
+     "iopub.status.idle": "2026-05-20T18:18:05.369281Z",
+     "shell.execute_reply": "2026-05-20T18:18:05.368135Z"
     },
     "papermill": {
-     "duration": 32.234596,
-     "end_time": "2026-05-20T16:22:36.489778+00:00",
+     "duration": 32.806293,
+     "end_time": "2026-05-20T18:18:05.370137+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:22:04.255182+00:00",
+     "start_time": "2026-05-20T18:17:32.563844+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2846,7 +2846,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "406c2435c70044009e294e809dd659b4",
+       "model_id": "686188f4f8a6447eaf9ceb7a48330402",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2861,14 +2861,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:22:04.288\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-21 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:17:32.598\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-21 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:22:10.994\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-22 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:17:39.282\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-22 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -3058,119 +3058,20 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 570.075172,
-   "end_time": "2026-05-20T16:22:37.226893+00:00",
+   "duration": 564.662705,
+   "end_time": "2026-05-20T18:18:06.109171+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "/mnt/share/homes/hjafari/repos/vivarium_gates_mncnh/tests/model_notebooks/interactive/branch_smoke_checks_aph_pph.ipynb",
    "output_path": "/mnt/share/homes/hjafari/repos/vivarium_gates_mncnh/tests/model_notebooks/interactive/executed/branch_smoke_checks_aph_pph.ipynb",
    "parameters": {},
-   "start_time": "2026-05-20T16:13:07.151721+00:00",
+   "start_time": "2026-05-20T18:08:41.446466+00:00",
    "version": "2.7.0"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "020d61750f894f5089018171bbd3bdd5": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_be31c330c522448eba99194e570ec6c7",
-       "placeholder": "​",
-       "style": "IPY_MODEL_f51c6d9b3d1e41339210a26577ac9ef8",
-       "tabbable": null,
-       "tooltip": null,
-       "value": "Step: 15"
-      }
-     },
-     "0a9a50d7428d4157bb2c964f40e594a2": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "VBoxModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "VBoxModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "VBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_2e6dd05053b44bf29ffb5ee10a57909e",
-        "IPY_MODEL_47f29dbab48f445ba4786f5e5dba50c1"
-       ],
-       "layout": "IPY_MODEL_957cdc189622402e8538def77a146d6a",
-       "tabbable": null,
-       "tooltip": null
-      }
-     },
-     "0c0367b356eb4228ace5ad628fc1bd6a": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "0cd37b18405d40a7ae79cc3373f05d28": {
+     "0b239ceffdf448caab2e07a10440ac9d": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HTMLStyleModel",
@@ -3188,369 +3089,7 @@
        "text_color": null
       }
      },
-     "0d918dd77d414880b18b91ea9c5f30ac": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_cdad056d7c5e44c9bafd98eed709333d",
-       "placeholder": "​",
-       "style": "IPY_MODEL_2d1b0742ff6b4131b58c69f56bfdc4b5",
-       "tabbable": null,
-       "tooltip": null,
-       "value": "Step: 2"
-      }
-     },
-     "124be4dbd6fb4ef2bc996a1cb555d874": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "VBoxModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "VBoxModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "VBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_2873c4b336d2406e91f2b12caa68b3a6",
-        "IPY_MODEL_864af82c7cdf46b5bb5e2d0d487d62c3"
-       ],
-       "layout": "IPY_MODEL_26b5c20eaef54c43ac11600513eec643",
-       "tabbable": null,
-       "tooltip": null
-      }
-     },
-     "1c4dc2ca0a0c4e21bc67a0204aba9f42": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "VBoxModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "VBoxModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "VBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_020d61750f894f5089018171bbd3bdd5",
-        "IPY_MODEL_38f2dcdcd6654f628cbfd2ba1b391550"
-       ],
-       "layout": "IPY_MODEL_407015ee78a043a79c95af4fefdd9abf",
-       "tabbable": null,
-       "tooltip": null
-      }
-     },
-     "1f9dbfd37e8e465d92b80d3aa3559c2c": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "IntProgressModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "IntProgressModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "ProgressView",
-       "bar_style": "success",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_abb98d105ffa40bd866af46514711578",
-       "max": 2,
-       "min": 0,
-       "orientation": "horizontal",
-       "style": "IPY_MODEL_a57216b6ce3e420cbb28bd14626f7e88",
-       "tabbable": null,
-       "tooltip": null,
-       "value": 2
-      }
-     },
-     "208265fa07164fa58d67d87b0816870c": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "background": null,
-       "description_width": "",
-       "font_size": null,
-       "text_color": null
-      }
-     },
-     "22ce4c1ff2fc4ceeb2ac7580ffdb03b7": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "26b5c20eaef54c43ac11600513eec643": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "2873c4b336d2406e91f2b12caa68b3a6": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_e2e3e0a1ee0440049e6901e86ab5fbc4",
-       "placeholder": "​",
-       "style": "IPY_MODEL_f4465e037a0047f69cdfee2fe89d0ccf",
-       "tabbable": null,
-       "tooltip": null,
-       "value": "Step: 19"
-      }
-     },
-     "2d1b0742ff6b4131b58c69f56bfdc4b5": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "background": null,
-       "description_width": "",
-       "font_size": null,
-       "text_color": null
-      }
-     },
-     "2d5cd621317e48b99dace34e00aced75": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "2e6dd05053b44bf29ffb5ee10a57909e": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_2d5cd621317e48b99dace34e00aced75",
-       "placeholder": "​",
-       "style": "IPY_MODEL_78b4d198bc8842529d5b6c1bf856063c",
-       "tabbable": null,
-       "tooltip": null,
-       "value": "Step: 15"
-      }
-     },
-     "38f2dcdcd6654f628cbfd2ba1b391550": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "IntProgressModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "IntProgressModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "ProgressView",
-       "bar_style": "success",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_4514d96bed2b406ea16525287233f4ac",
-       "max": 15,
-       "min": 0,
-       "orientation": "horizontal",
-       "style": "IPY_MODEL_8c8d1a89424742a393f629967c059c91",
-       "tabbable": null,
-       "tooltip": null,
-       "value": 15
-      }
-     },
-     "3f60885c8bab4798aeff3104331961e0": {
+     "0ccbcfc005234d27b5a89ca8b5222a28": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "ProgressStyleModel",
@@ -3566,294 +3105,7 @@
        "description_width": ""
       }
      },
-     "406c2435c70044009e294e809dd659b4": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "VBoxModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "VBoxModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "VBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_0d918dd77d414880b18b91ea9c5f30ac",
-        "IPY_MODEL_1f9dbfd37e8e465d92b80d3aa3559c2c"
-       ],
-       "layout": "IPY_MODEL_a1f6e3765b194b5fa32fb88fb20976f3",
-       "tabbable": null,
-       "tooltip": null
-      }
-     },
-     "407015ee78a043a79c95af4fefdd9abf": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "4514d96bed2b406ea16525287233f4ac": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "46f1e6361533451380b4e8f99e1d4efe": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "IntProgressModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "IntProgressModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "ProgressView",
-       "bar_style": "success",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_4dc3f4730e5b457c822315faa496025e",
-       "max": 15,
-       "min": 0,
-       "orientation": "horizontal",
-       "style": "IPY_MODEL_3f60885c8bab4798aeff3104331961e0",
-       "tabbable": null,
-       "tooltip": null,
-       "value": 15
-      }
-     },
-     "47f29dbab48f445ba4786f5e5dba50c1": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "IntProgressModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "IntProgressModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "ProgressView",
-       "bar_style": "success",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_0c0367b356eb4228ace5ad628fc1bd6a",
-       "max": 15,
-       "min": 0,
-       "orientation": "horizontal",
-       "style": "IPY_MODEL_e4536914e8b84f00b487c2d1c8072ac6",
-       "tabbable": null,
-       "tooltip": null,
-       "value": 15
-      }
-     },
-     "4a0529fa4fdd4801b17216138c0af6a2": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "4dc3f4730e5b457c822315faa496025e": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "63b21c3ed4034759ad111f9891c21a42": {
+     "0e113c9d284649e69e0a3b9c1aa9a2c7": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "ProgressStyleModel",
@@ -3869,130 +3121,62 @@
        "description_width": ""
       }
      },
-     "654ae38a4f234d91901f94316453596a": {
+     "1069830cb3374ac698cd75e060618f03": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
-      "model_name": "IntProgressModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "IntProgressModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "ProgressView",
-       "bar_style": "success",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_c744618dec0a4c1989141ecd8111f8e0",
-       "max": 20,
-       "min": 0,
-       "orientation": "horizontal",
-       "style": "IPY_MODEL_63b21c3ed4034759ad111f9891c21a42",
-       "tabbable": null,
-       "tooltip": null,
-       "value": 20
-      }
-     },
-     "6a09e86f297a423c982450af1a2f0d23": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "78b4d198bc8842529d5b6c1bf856063c": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLStyleModel",
+      "model_name": "ProgressStyleModel",
       "state": {
        "_model_module": "@jupyter-widgets/controls",
        "_model_module_version": "2.0.0",
-       "_model_name": "HTMLStyleModel",
+       "_model_name": "ProgressStyleModel",
        "_view_count": null,
        "_view_module": "@jupyter-widgets/base",
        "_view_module_version": "2.0.0",
        "_view_name": "StyleView",
-       "background": null,
-       "description_width": "",
-       "font_size": null,
-       "text_color": null
+       "bar_color": null,
+       "description_width": ""
       }
      },
-     "864af82c7cdf46b5bb5e2d0d487d62c3": {
+     "13d684e5581a4aa7aeb47e8c471300d5": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
-      "model_name": "IntProgressModel",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "1853c68406774f5eae9839dfe2a247b5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "VBoxModel",
       "state": {
        "_dom_classes": [],
        "_model_module": "@jupyter-widgets/controls",
        "_model_module_version": "2.0.0",
-       "_model_name": "IntProgressModel",
+       "_model_name": "VBoxModel",
        "_view_count": null,
        "_view_module": "@jupyter-widgets/controls",
        "_view_module_version": "2.0.0",
-       "_view_name": "ProgressView",
-       "bar_style": "success",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_cb4465cf02684a60a894d7c49f767ccb",
-       "max": 19,
-       "min": 0,
-       "orientation": "horizontal",
-       "style": "IPY_MODEL_9b92fa4ac94940918d467ca85f062616",
+       "_view_name": "VBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_97c0d125e7ad45faa139747c9dd10411",
+        "IPY_MODEL_7399069eba6a4179a6aa47852fcb90a6"
+       ],
+       "layout": "IPY_MODEL_3800333416c2418eb4e7be656afd4faa",
        "tabbable": null,
-       "tooltip": null,
-       "value": 19
+       "tooltip": null
       }
      },
-     "86a4d7c5c51745bebd6d4c8c593aba56": {
+     "1b05a3c1c9f64b2096490131adb09a7a": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HTMLModel",
@@ -4007,15 +3191,68 @@
        "_view_name": "HTMLView",
        "description": "",
        "description_allow_html": false,
-       "layout": "IPY_MODEL_22ce4c1ff2fc4ceeb2ac7580ffdb03b7",
+       "layout": "IPY_MODEL_63b23576f40b4cc28c2a3226722313bf",
        "placeholder": "​",
-       "style": "IPY_MODEL_0cd37b18405d40a7ae79cc3373f05d28",
+       "style": "IPY_MODEL_fd747fdbe22243c292977a5a8ea18f43",
        "tabbable": null,
        "tooltip": null,
        "value": "Step: 20"
       }
      },
-     "8c8d1a89424742a393f629967c059c91": {
+     "1d33368307ca4d4882f7dcbc308ed66a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "1d714807fe094b40b0806481737dbe1c": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "ProgressStyleModel",
@@ -4031,7 +3268,7 @@
        "description_width": ""
       }
      },
-     "957cdc189622402e8538def77a146d6a": {
+     "1f73a7135a9d44309f53b3fb2c2d1932": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -4084,69 +3321,7 @@
        "width": null
       }
      },
-     "9b92fa4ac94940918d467ca85f062616": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "ProgressStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "bar_color": null,
-       "description_width": ""
-      }
-     },
-     "9bc0cb7251ca4faf85ebe7a2dec5a0c7": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "VBoxModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "VBoxModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "VBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_a0bd10c42d334816b7b063c49cbb4426",
-        "IPY_MODEL_46f1e6361533451380b4e8f99e1d4efe"
-       ],
-       "layout": "IPY_MODEL_dbbfcefced824fa6b9c9d80e152c5df6",
-       "tabbable": null,
-       "tooltip": null
-      }
-     },
-     "a0bd10c42d334816b7b063c49cbb4426": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_4a0529fa4fdd4801b17216138c0af6a2",
-       "placeholder": "​",
-       "style": "IPY_MODEL_208265fa07164fa58d67d87b0816870c",
-       "tabbable": null,
-       "tooltip": null,
-       "value": "Step: 15"
-      }
-     },
-     "a1f6e3765b194b5fa32fb88fb20976f3": {
+     "1f78b10072d844aabcf1ee6a31b9f746": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -4199,433 +3374,7 @@
        "width": null
       }
      },
-     "a57216b6ce3e420cbb28bd14626f7e88": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "ProgressStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "bar_color": null,
-       "description_width": ""
-      }
-     },
-     "abb98d105ffa40bd866af46514711578": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "be31c330c522448eba99194e570ec6c7": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "c744618dec0a4c1989141ecd8111f8e0": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "cb4465cf02684a60a894d7c49f767ccb": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "cdad056d7c5e44c9bafd98eed709333d": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "dbbfcefced824fa6b9c9d80e152c5df6": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "dc190b979f3940dc900d6c7cd367a05b": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "VBoxModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "VBoxModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "VBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_86a4d7c5c51745bebd6d4c8c593aba56",
-        "IPY_MODEL_654ae38a4f234d91901f94316453596a"
-       ],
-       "layout": "IPY_MODEL_6a09e86f297a423c982450af1a2f0d23",
-       "tabbable": null,
-       "tooltip": null
-      }
-     },
-     "e2e3e0a1ee0440049e6901e86ab5fbc4": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "e4536914e8b84f00b487c2d1c8072ac6": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "ProgressStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "bar_color": null,
-       "description_width": ""
-      }
-     },
-     "f4465e037a0047f69cdfee2fe89d0ccf": {
+     "29bf9941059a4474885e9121a40dec19": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HTMLStyleModel",
@@ -4643,7 +3392,1258 @@
        "text_color": null
       }
      },
-     "f51c6d9b3d1e41339210a26577ac9ef8": {
+     "2acef119274d49dda9173771d364c894": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_65006acea4064dbeabae08bd87ba79b6",
+       "placeholder": "​",
+       "style": "IPY_MODEL_29bf9941059a4474885e9121a40dec19",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Step: 2"
+      }
+     },
+     "2b4f0c91f9284efb8cd7762405d2f294": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "IntProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_1f73a7135a9d44309f53b3fb2c2d1932",
+       "max": 2,
+       "min": 0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_1069830cb3374ac698cd75e060618f03",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 2
+      }
+     },
+     "2f57a3cdbd0b4b49846d78c3ecb4eb01": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "31470ed1a3c547018fc09f79c39bb937": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_584d9329ecd545daa9788cfee91f7f32",
+       "placeholder": "​",
+       "style": "IPY_MODEL_0b239ceffdf448caab2e07a10440ac9d",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Step: 15"
+      }
+     },
+     "3800333416c2418eb4e7be656afd4faa": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "38bf795a3e6649d3ad20d1e37a8fd65f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "VBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "VBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_6e5166c440b542fe9fb7f353c3dd742d",
+        "IPY_MODEL_81b2c5a2d00241d48b0e19d1bb28c616"
+       ],
+       "layout": "IPY_MODEL_2f57a3cdbd0b4b49846d78c3ecb4eb01",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "3902e80a64d3440380fa335d53ce11f5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "IntProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_87ab684a314943489309b9b33e912cf0",
+       "max": 15,
+       "min": 0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_0e113c9d284649e69e0a3b9c1aa9a2c7",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 15
+      }
+     },
+     "4438f2206ff449e78b0ec92f6ad2f083": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "4a83337a43014b9a90639c77282fdc3c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "VBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "VBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_31470ed1a3c547018fc09f79c39bb937",
+        "IPY_MODEL_d6f0bff73bb04953889670120965e9d9"
+       ],
+       "layout": "IPY_MODEL_512619f290c64572a3bc6a1619baa175",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "512619f290c64572a3bc6a1619baa175": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "5462ea0bc3bb4a3a90ad80b13cd2e242": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "584d9329ecd545daa9788cfee91f7f32": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "5ef914d4be7147d9a3570c8912e18db5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "63b23576f40b4cc28c2a3226722313bf": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "65006acea4064dbeabae08bd87ba79b6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "686188f4f8a6447eaf9ceb7a48330402": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "VBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "VBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_2acef119274d49dda9173771d364c894",
+        "IPY_MODEL_2b4f0c91f9284efb8cd7762405d2f294"
+       ],
+       "layout": "IPY_MODEL_b7cc7521cff54ddaa96224fb18e030ae",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "6e5166c440b542fe9fb7f353c3dd742d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_1f78b10072d844aabcf1ee6a31b9f746",
+       "placeholder": "​",
+       "style": "IPY_MODEL_c743b022c1704ff48d7d6ed59d79621c",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Step: 15"
+      }
+     },
+     "7399069eba6a4179a6aa47852fcb90a6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "IntProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_b42956b55c684d9db7d4af4db7576118",
+       "max": 19,
+       "min": 0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_1d714807fe094b40b0806481737dbe1c",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 19
+      }
+     },
+     "81b2c5a2d00241d48b0e19d1bb28c616": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "IntProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_1d33368307ca4d4882f7dcbc308ed66a",
+       "max": 15,
+       "min": 0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_d74c664883da441c8114bc29904823eb",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 15
+      }
+     },
+     "85025cbf309d4351b93ff60cdea2e507": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "VBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "VBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_b43de5814fa3485c8d4ed281394641b7",
+        "IPY_MODEL_3902e80a64d3440380fa335d53ce11f5"
+       ],
+       "layout": "IPY_MODEL_bee1273f36474272a180a9d22eaf23ed",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "86aacd80a00d46f9a3ffe74ee080357d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "VBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "VBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_1b05a3c1c9f64b2096490131adb09a7a",
+        "IPY_MODEL_8a396dd2075c4d2daf5b646b42ea273c"
+       ],
+       "layout": "IPY_MODEL_5ef914d4be7147d9a3570c8912e18db5",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "87ab684a314943489309b9b33e912cf0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "8a396dd2075c4d2daf5b646b42ea273c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "IntProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_c56f807c89e64d6da50cb96c705ea9dd",
+       "max": 20,
+       "min": 0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_0ccbcfc005234d27b5a89ca8b5222a28",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 20
+      }
+     },
+     "97c0d125e7ad45faa139747c9dd10411": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_bf995729e347490ba63d1afb54754566",
+       "placeholder": "​",
+       "style": "IPY_MODEL_be5a2039a5744f588b58b18d04cea2c5",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Step: 19"
+      }
+     },
+     "b42956b55c684d9db7d4af4db7576118": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "b43de5814fa3485c8d4ed281394641b7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_de401ce3ec184524aeba9d15461642fa",
+       "placeholder": "​",
+       "style": "IPY_MODEL_4438f2206ff449e78b0ec92f6ad2f083",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Step: 15"
+      }
+     },
+     "b7cc7521cff54ddaa96224fb18e030ae": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "be5a2039a5744f588b58b18d04cea2c5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "bee1273f36474272a180a9d22eaf23ed": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "bf995729e347490ba63d1afb54754566": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "c56f807c89e64d6da50cb96c705ea9dd": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "c743b022c1704ff48d7d6ed59d79621c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "d6f0bff73bb04953889670120965e9d9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "IntProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_5462ea0bc3bb4a3a90ad80b13cd2e242",
+       "max": 15,
+       "min": 0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_13d684e5581a4aa7aeb47e8c471300d5",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 15
+      }
+     },
+     "d74c664883da441c8114bc29904823eb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "de401ce3ec184524aeba9d15461642fa": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "fd747fdbe22243c292977a5a8ea18f43": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HTMLStyleModel",

--- a/tests/model_notebooks/interactive/executed/branch_smoke_checks_aph_pph.ipynb
+++ b/tests/model_notebooks/interactive/executed/branch_smoke_checks_aph_pph.ipynb
@@ -5,10 +5,10 @@
    "id": "75f12b55",
    "metadata": {
     "papermill": {
-     "duration": 0.007491,
-     "end_time": "2026-05-19T21:26:41.612703+00:00",
+     "duration": 0.010913,
+     "end_time": "2026-05-20T16:13:08.429757+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:26:41.605212+00:00",
+     "start_time": "2026-05-20T16:13:08.418844+00:00",
      "status": "completed"
     },
     "tags": []
@@ -34,16 +34,16 @@
    "id": "a45239fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:26:41.624906Z",
-     "iopub.status.busy": "2026-05-19T21:26:41.624706Z",
-     "iopub.status.idle": "2026-05-19T21:26:45.336229Z",
-     "shell.execute_reply": "2026-05-19T21:26:45.334805Z"
+     "iopub.execute_input": "2026-05-20T16:13:08.444982Z",
+     "iopub.status.busy": "2026-05-20T16:13:08.444373Z",
+     "iopub.status.idle": "2026-05-20T16:13:10.347151Z",
+     "shell.execute_reply": "2026-05-20T16:13:10.345609Z"
     },
     "papermill": {
-     "duration": 3.718801,
-     "end_time": "2026-05-19T21:26:45.337103+00:00",
+     "duration": 1.911366,
+     "end_time": "2026-05-20T16:13:10.348001+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:26:41.618302+00:00",
+     "start_time": "2026-05-20T16:13:08.436635+00:00",
      "status": "completed"
     },
     "tags": []
@@ -78,16 +78,16 @@
    "id": "b7f5bc48",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:26:45.350351Z",
-     "iopub.status.busy": "2026-05-19T21:26:45.350031Z",
-     "iopub.status.idle": "2026-05-19T21:26:48.752489Z",
-     "shell.execute_reply": "2026-05-19T21:26:48.751034Z"
+     "iopub.execute_input": "2026-05-20T16:13:10.362788Z",
+     "iopub.status.busy": "2026-05-20T16:13:10.362371Z",
+     "iopub.status.idle": "2026-05-20T16:13:13.161285Z",
+     "shell.execute_reply": "2026-05-20T16:13:13.159690Z"
     },
     "papermill": {
-     "duration": 3.409985,
-     "end_time": "2026-05-19T21:26:48.753318+00:00",
+     "duration": 2.807098,
+     "end_time": "2026-05-20T16:13:13.162057+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:26:45.343333+00:00",
+     "start_time": "2026-05-20T16:13:10.354959+00:00",
      "status": "completed"
     },
     "tags": []
@@ -166,10 +166,10 @@
    "id": "3e2b43f4",
    "metadata": {
     "papermill": {
-     "duration": 0.005639,
-     "end_time": "2026-05-19T21:26:48.765051+00:00",
+     "duration": 0.005922,
+     "end_time": "2026-05-20T16:13:13.174775+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:26:48.759412+00:00",
+     "start_time": "2026-05-20T16:13:13.168853+00:00",
      "status": "completed"
     },
     "tags": []
@@ -184,16 +184,16 @@
    "id": "d0c3f9be",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:26:48.777681Z",
-     "iopub.status.busy": "2026-05-19T21:26:48.777461Z",
-     "iopub.status.idle": "2026-05-19T21:28:33.344902Z",
-     "shell.execute_reply": "2026-05-19T21:28:33.341793Z"
+     "iopub.execute_input": "2026-05-20T16:13:13.188026Z",
+     "iopub.status.busy": "2026-05-20T16:13:13.187787Z",
+     "iopub.status.idle": "2026-05-20T16:15:01.706499Z",
+     "shell.execute_reply": "2026-05-20T16:15:01.705187Z"
     },
     "papermill": {
-     "duration": 104.575002,
-     "end_time": "2026-05-19T21:28:33.345752+00:00",
+     "duration": 108.526875,
+     "end_time": "2026-05-20T16:15:01.707776+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:26:48.770750+00:00",
+     "start_time": "2026-05-20T16:13:13.180901+00:00",
      "status": "completed"
     },
     "tags": []
@@ -203,21 +203,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:26:49.037\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:13:13.315\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:26:49.039\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:13:13.316\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:26:49.040\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:13:13.316\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
      ]
     },
     {
@@ -262,133 +262,133 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:27:31.799\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:13:55.815\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:27:31.801\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:13:55.816\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:27:31.986\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:13:56.017\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:27:31.987\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:13:56.018\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:27:31.987\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:13:56.018\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:27:31.988\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:13:56.019\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:27:31.989\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:13:56.019\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:27:31.989\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:13:56.020\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:27:31.990\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:13:56.021\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:27:31.990\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:13:56.021\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:27:31.991\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:13:56.022\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:27:31.992\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:13:56.023\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:27:31.992\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:13:56.023\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:27:31.996\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:13:56.024\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:27:31.997\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:13:56.028\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:27:31.998\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:13:56.029\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:27:31.998\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:13:56.030\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:27:31.999\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
+      "\u001b[32m2026-05-20 09:13:56.031\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
       "['ferritin_screening_coverage', 'hemoglobin_screening_coverage', 'sex']\u001b[0m\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bc4448da66f74f199671d6cacfac52ef",
+       "model_id": "1c4dc2ca0a0c4e21bc67a0204aba9f42",
        "version_major": 2,
        "version_minor": 0
       },
@@ -403,126 +403,126 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:27:34.657\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:13:58.996\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:27:49.129\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:14:14.680\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:27:50.247\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:14:15.967\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:27:51.809\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:14:17.702\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:28:07.843\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:14:34.692\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:28:25.605\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:14:53.473\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:28:26.347\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:14:54.238\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:28:26.452\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:14:54.347\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:28:27.162\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:14:55.084\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:28:27.883\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:14:55.842\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:28:28.567\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:14:56.571\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:28:29.341\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:14:57.399\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:28:30.025\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:14:58.095\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:28:30.746\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:14:58.823\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:28:31.426\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:14:59.571\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:28:32.110\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:15:00.323\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:28:32.135\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:15:00.350\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:28:32.844\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:15:01.128\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -696,10 +696,10 @@
    "id": "3ab3f53c",
    "metadata": {
     "papermill": {
-     "duration": 0.008469,
-     "end_time": "2026-05-19T21:28:33.362692+00:00",
+     "duration": 0.009196,
+     "end_time": "2026-05-20T16:15:01.726252+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:28:33.354223+00:00",
+     "start_time": "2026-05-20T16:15:01.717056+00:00",
      "status": "completed"
     },
     "tags": []
@@ -714,16 +714,16 @@
    "id": "e181f0a6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:28:33.379932Z",
-     "iopub.status.busy": "2026-05-19T21:28:33.379661Z",
-     "iopub.status.idle": "2026-05-19T21:30:23.235172Z",
-     "shell.execute_reply": "2026-05-19T21:30:23.233894Z"
+     "iopub.execute_input": "2026-05-20T16:15:01.746347Z",
+     "iopub.status.busy": "2026-05-20T16:15:01.746060Z",
+     "iopub.status.idle": "2026-05-20T16:16:48.779904Z",
+     "shell.execute_reply": "2026-05-20T16:16:48.778463Z"
     },
     "papermill": {
-     "duration": 109.874134,
-     "end_time": "2026-05-19T21:30:23.244715+00:00",
+     "duration": 107.047253,
+     "end_time": "2026-05-20T16:16:48.783008+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:28:33.370581+00:00",
+     "start_time": "2026-05-20T16:15:01.735755+00:00",
      "status": "completed"
     },
     "tags": []
@@ -733,21 +733,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:28:33.392\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:15:01.761\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:28:33.393\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:15:01.762\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:28:33.394\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:15:01.763\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
      ]
     },
     {
@@ -786,133 +786,133 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:29:16.077\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:15:43.108\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:29:16.078\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:15:43.109\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:29:16.318\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:15:43.288\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:29:16.318\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:15:43.289\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:29:16.320\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:15:43.290\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:29:16.321\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:15:43.290\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:29:16.322\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:15:43.291\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:29:16.323\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:15:43.291\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:29:16.324\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:15:43.292\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:29:16.324\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:15:43.292\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:29:16.325\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:15:43.293\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:29:16.326\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:15:43.293\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:29:16.327\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:15:43.294\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:29:16.328\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:15:43.294\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:29:16.329\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:15:43.295\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:29:16.335\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:15:43.295\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:29:16.336\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:15:43.296\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:29:16.337\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
+      "\u001b[32m2026-05-20 09:15:43.297\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
       "['ferritin_screening_coverage', 'hemoglobin_screening_coverage', 'sex']\u001b[0m\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "970c215b585e457684ba881df1eadd76",
+       "model_id": "124be4dbd6fb4ef2bc996a1cb555d874",
        "version_major": 2,
        "version_minor": 0
       },
@@ -927,161 +927,161 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:29:19.068\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:15:45.769\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:29:33.541\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:16:00.083\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:29:34.648\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:16:01.148\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:29:36.204\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:16:02.640\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:29:51.918\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:16:18.046\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:30:09.720\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:16:35.558\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:30:10.450\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:16:36.273\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:30:10.555\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:16:36.374\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:30:11.259\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:16:37.066\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:30:11.976\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:16:37.795\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:30:12.660\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:16:38.471\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:30:13.422\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:16:39.211\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:30:14.106\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:16:39.841\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:30:14.825\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:16:40.567\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:30:15.507\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:16:41.255\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:30:16.197\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:16:41.935\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:30:16.222\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:16:41.960\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:30:16.931\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:16:42.645\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:30:17.069\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-16 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:16:42.779\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-16 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:30:17.777\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:16:43.490\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:30:17.896\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-17 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:16:43.602\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-17 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:30:18.563\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-18 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:16:44.265\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-18 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:30:19.240\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-19 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:16:44.920\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-19 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -1127,10 +1127,10 @@
    "id": "bcd55204",
    "metadata": {
     "papermill": {
-     "duration": 0.010638,
-     "end_time": "2026-05-19T21:30:23.266338+00:00",
+     "duration": 0.011019,
+     "end_time": "2026-05-20T16:16:48.805355+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:30:23.255700+00:00",
+     "start_time": "2026-05-20T16:16:48.794336+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1145,16 +1145,16 @@
    "id": "4e074598",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:30:23.289718Z",
-     "iopub.status.busy": "2026-05-19T21:30:23.289295Z",
-     "iopub.status.idle": "2026-05-19T21:33:51.038155Z",
-     "shell.execute_reply": "2026-05-19T21:33:51.036900Z"
+     "iopub.execute_input": "2026-05-20T16:16:48.828470Z",
+     "iopub.status.busy": "2026-05-20T16:16:48.828196Z",
+     "iopub.status.idle": "2026-05-20T16:20:01.684170Z",
+     "shell.execute_reply": "2026-05-20T16:20:01.683116Z"
     },
     "papermill": {
-     "duration": 207.762026,
-     "end_time": "2026-05-19T21:33:51.039129+00:00",
+     "duration": 192.869077,
+     "end_time": "2026-05-20T16:20:01.685060+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:30:23.277103+00:00",
+     "start_time": "2026-05-20T16:16:48.815983+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1164,21 +1164,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:30:23.310\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:16:48.849\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:30:23.311\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:16:48.850\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:30:23.311\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:16:48.850\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
      ]
     },
     {
@@ -1208,13 +1208,7 @@
      "output_type": "stream",
      "text": [
       "/ihme/homes/hjafari/miniconda3/envs/vivarium_gates_mncnh_simulation/lib/python3.11/site-packages/vivarium/framework/lookup/interpolation.py:72: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.\n",
-      "  sub_tables = list(self.data.groupby(list(self.categorical_parameters)))\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "  sub_tables = list(self.data.groupby(list(self.categorical_parameters)))\n",
       "/ihme/homes/hjafari/miniconda3/envs/vivarium_gates_mncnh_simulation/lib/python3.11/site-packages/vivarium/framework/lookup/interpolation.py:72: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.\n",
       "  sub_tables = list(self.data.groupby(list(self.categorical_parameters)))\n"
      ]
@@ -1223,133 +1217,133 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:31:04.787\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:17:28.685\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:31:04.788\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:17:28.686\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:31:04.992\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:17:28.874\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:31:04.993\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:17:28.874\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:31:04.994\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:17:28.875\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:31:04.994\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:17:28.876\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:31:04.995\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:17:28.876\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:31:04.996\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:17:28.877\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:31:04.996\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:17:28.877\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:31:04.997\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:17:28.878\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:31:04.997\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:17:28.879\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:31:04.998\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:17:28.879\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:31:04.999\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:17:28.880\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:31:04.999\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:17:28.881\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:31:05.000\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:17:28.881\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:31:05.000\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:17:28.882\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:31:05.001\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:17:28.882\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:31:05.002\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
+      "\u001b[32m2026-05-20 09:17:28.883\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
       "['ferritin_screening_coverage', 'hemoglobin_screening_coverage', 'sex']\u001b[0m\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "34361f29cb644a9aaeb755b51f799cca",
+       "model_id": "0a9a50d7428d4157bb2c964f40e594a2",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1364,147 +1358,147 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:31:07.618\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:17:31.309\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:31:22.338\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:17:44.874\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:31:23.476\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:17:45.910\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:31:25.053\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:17:47.356\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:31:41.526\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:18:02.309\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:31:59.625\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:18:19.190\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:00.371\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:18:19.891\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:00.477\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:18:19.991\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:01.208\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:18:20.655\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:01.950\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:18:21.327\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:02.641\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:18:21.968\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:03.437\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:18:22.691\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:04.132\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:18:23.327\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:04.909\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:18:24.008\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:05.607\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:18:24.652\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:06.275\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:18:25.316\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:06.301\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:18:25.341\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:07.002\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:18:26.012\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:07.173\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:18:26.166\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:07.174\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:18:26.167\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:07.174\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:18:26.167\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
      ]
     },
     {
@@ -1543,133 +1537,133 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:48.984\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:05.012\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:48.985\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:05.013\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:49.179\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:05.201\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:49.180\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:05.202\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:49.182\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:05.202\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:49.182\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:05.203\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:49.184\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:05.203\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:49.185\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:05.204\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:49.185\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:05.204\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:49.186\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:05.205\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:49.186\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:05.205\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:49.187\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:05.208\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:49.188\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:05.209\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:49.188\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:05.209\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:49.189\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:05.210\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:49.190\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:05.210\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:49.190\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:05.211\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:49.191\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
+      "\u001b[32m2026-05-20 09:19:05.212\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
       "['ferritin_screening_coverage', 'hemoglobin_screening_coverage', 'sex']\u001b[0m\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0fd25d19d49f4f8f8582fdf4b406472f",
+       "model_id": "9bc0cb7251ca4faf85ebe7a2dec5a0c7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1684,126 +1678,126 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:32:51.748\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:07.711\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:33:06.415\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:21.023\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:33:07.548\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:22.018\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:33:09.118\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:23.400\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:33:25.176\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:38.455\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:33:43.511\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:55.050\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:33:44.283\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:55.713\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:33:44.392\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:55.811\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:33:45.133\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:56.453\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:33:45.884\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:57.100\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:33:46.585\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:57.721\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:33:47.369\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:58.407\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:33:48.037\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:58.996\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:33:48.759\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:19:59.641\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:33:49.441\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:00.254\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:33:50.129\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:00.869\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:33:50.154\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:00.894\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:33:50.870\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:01.531\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -1952,16 +1946,16 @@
    "id": "d94fd4fd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:33:51.071882Z",
-     "iopub.status.busy": "2026-05-19T21:33:51.071496Z",
-     "iopub.status.idle": "2026-05-19T21:33:51.087486Z",
-     "shell.execute_reply": "2026-05-19T21:33:51.086261Z"
+     "iopub.execute_input": "2026-05-20T16:20:01.717436Z",
+     "iopub.status.busy": "2026-05-20T16:20:01.717095Z",
+     "iopub.status.idle": "2026-05-20T16:20:01.731917Z",
+     "shell.execute_reply": "2026-05-20T16:20:01.730769Z"
     },
     "papermill": {
-     "duration": 0.033663,
-     "end_time": "2026-05-19T21:33:51.089022+00:00",
+     "duration": 0.031559,
+     "end_time": "2026-05-20T16:20:01.732644+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:33:51.055359+00:00",
+     "start_time": "2026-05-20T16:20:01.701085+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2042,10 +2036,10 @@
    "id": "f426e5db",
    "metadata": {
     "papermill": {
-     "duration": 0.014429,
-     "end_time": "2026-05-19T21:33:51.120293+00:00",
+     "duration": 0.01453,
+     "end_time": "2026-05-20T16:20:01.761917+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:33:51.105864+00:00",
+     "start_time": "2026-05-20T16:20:01.747387+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2062,16 +2056,16 @@
    "id": "07f027aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:33:51.152146Z",
-     "iopub.status.busy": "2026-05-19T21:33:51.151801Z",
-     "iopub.status.idle": "2026-05-19T21:33:51.192407Z",
-     "shell.execute_reply": "2026-05-19T21:33:51.191349Z"
+     "iopub.execute_input": "2026-05-20T16:20:01.792188Z",
+     "iopub.status.busy": "2026-05-20T16:20:01.791960Z",
+     "iopub.status.idle": "2026-05-20T16:20:01.828633Z",
+     "shell.execute_reply": "2026-05-20T16:20:01.827397Z"
     },
     "papermill": {
-     "duration": 0.057471,
-     "end_time": "2026-05-19T21:33:51.193625+00:00",
+     "duration": 0.052382,
+     "end_time": "2026-05-20T16:20:01.829325+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:33:51.136154+00:00",
+     "start_time": "2026-05-20T16:20:01.776943+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2183,10 +2177,10 @@
    "id": "4c744c2f",
    "metadata": {
     "papermill": {
-     "duration": 0.015027,
-     "end_time": "2026-05-19T21:33:51.224124+00:00",
+     "duration": 0.014836,
+     "end_time": "2026-05-20T16:20:01.859613+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:33:51.209097+00:00",
+     "start_time": "2026-05-20T16:20:01.844777+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2203,16 +2197,16 @@
    "id": "b2297d29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:33:51.256107Z",
-     "iopub.status.busy": "2026-05-19T21:33:51.255735Z",
-     "iopub.status.idle": "2026-05-19T21:33:51.391476Z",
-     "shell.execute_reply": "2026-05-19T21:33:51.390599Z"
+     "iopub.execute_input": "2026-05-20T16:20:01.893700Z",
+     "iopub.status.busy": "2026-05-20T16:20:01.893457Z",
+     "iopub.status.idle": "2026-05-20T16:20:02.032840Z",
+     "shell.execute_reply": "2026-05-20T16:20:02.031615Z"
     },
     "papermill": {
-     "duration": 0.153661,
-     "end_time": "2026-05-19T21:33:51.392453+00:00",
+     "duration": 0.157425,
+     "end_time": "2026-05-20T16:20:02.033563+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:33:51.238792+00:00",
+     "start_time": "2026-05-20T16:20:01.876138+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2260,10 +2254,10 @@
    "id": "7277cedc",
    "metadata": {
     "papermill": {
-     "duration": 0.014391,
-     "end_time": "2026-05-19T21:33:51.421924+00:00",
+     "duration": 0.014704,
+     "end_time": "2026-05-20T16:20:02.063753+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:33:51.407533+00:00",
+     "start_time": "2026-05-20T16:20:02.049049+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2282,16 +2276,16 @@
    "id": "448f9016",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:33:51.453866Z",
-     "iopub.status.busy": "2026-05-19T21:33:51.453648Z",
-     "iopub.status.idle": "2026-05-19T21:36:02.581379Z",
-     "shell.execute_reply": "2026-05-19T21:36:02.580186Z"
+     "iopub.execute_input": "2026-05-20T16:20:02.095666Z",
+     "iopub.status.busy": "2026-05-20T16:20:02.095485Z",
+     "iopub.status.idle": "2026-05-20T16:22:04.197666Z",
+     "shell.execute_reply": "2026-05-20T16:22:04.196613Z"
     },
     "papermill": {
-     "duration": 131.149385,
-     "end_time": "2026-05-19T21:36:02.585922+00:00",
+     "duration": 122.121538,
+     "end_time": "2026-05-20T16:22:04.199940+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:33:51.436537+00:00",
+     "start_time": "2026-05-20T16:20:02.078402+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2301,21 +2295,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:33:51.469\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:02.109\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:33:51.469\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:02.110\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:33:51.470\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:02.111\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
      ]
     },
     {
@@ -2333,6 +2327,14 @@
       "/ihme/homes/hjafari/miniconda3/envs/vivarium_gates_mncnh_simulation/lib/python3.11/site-packages/vivarium/framework/lookup/interpolation.py:72: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.\n",
       "  sub_tables = list(self.data.groupby(list(self.categorical_parameters)))\n",
       "/ihme/homes/hjafari/miniconda3/envs/vivarium_gates_mncnh_simulation/lib/python3.11/site-packages/vivarium/framework/lookup/interpolation.py:72: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.\n",
+      "  sub_tables = list(self.data.groupby(list(self.categorical_parameters)))\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/ihme/homes/hjafari/miniconda3/envs/vivarium_gates_mncnh_simulation/lib/python3.11/site-packages/vivarium/framework/lookup/interpolation.py:72: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.\n",
       "  sub_tables = list(self.data.groupby(list(self.categorical_parameters)))\n",
       "/ihme/homes/hjafari/miniconda3/envs/vivarium_gates_mncnh_simulation/lib/python3.11/site-packages/vivarium/framework/lookup/interpolation.py:72: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.\n",
       "  sub_tables = list(self.data.groupby(list(self.categorical_parameters)))\n",
@@ -2345,8 +2347,6 @@
      "output_type": "stream",
      "text": [
       "/ihme/homes/hjafari/miniconda3/envs/vivarium_gates_mncnh_simulation/lib/python3.11/site-packages/vivarium/framework/lookup/interpolation.py:72: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.\n",
-      "  sub_tables = list(self.data.groupby(list(self.categorical_parameters)))\n",
-      "/ihme/homes/hjafari/miniconda3/envs/vivarium_gates_mncnh_simulation/lib/python3.11/site-packages/vivarium/framework/lookup/interpolation.py:72: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.\n",
       "  sub_tables = list(self.data.groupby(list(self.categorical_parameters)))\n"
      ]
     },
@@ -2354,133 +2354,133 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:34:33.332\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:41.024\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:34:33.333\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:41.025\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:34:33.528\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:41.217\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:34:33.529\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:41.218\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:34:33.530\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:41.218\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:34:33.530\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:41.219\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:34:33.531\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:41.219\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:34:33.532\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:41.220\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:34:33.532\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:41.220\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:34:33.533\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:41.221\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:34:33.533\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:41.222\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:34:33.534\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:41.224\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:34:33.535\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:41.225\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:34:33.535\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:41.226\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:34:33.536\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:41.226\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:34:33.537\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:41.227\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:34:33.537\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:41.227\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:34:33.538\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
+      "\u001b[32m2026-05-20 09:20:41.228\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
       "['ferritin_screening_coverage', 'hemoglobin_screening_coverage', 'sex']\u001b[0m\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3bcd3a951288427c94aed222a9576e4b",
+       "model_id": "dc190b979f3940dc900d6c7cd367a05b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2495,168 +2495,168 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:34:36.285\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:43.579\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:34:50.697\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:57.040\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:34:51.825\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:58.059\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:34:53.359\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:20:59.445\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:35:09.391\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:21:14.547\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:35:27.417\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:21:31.254\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:35:28.161\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:21:31.919\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:35:28.270\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:21:32.018\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:35:28.975\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:21:32.655\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:35:29.691\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:21:33.308\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:35:30.354\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:21:33.917\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:35:31.112\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:21:34.606\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:35:31.789\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:21:35.212\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:35:32.512\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:21:35.859\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:35:33.218\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:21:36.469\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:35:33.924\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:21:37.086\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:35:33.950\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:21:37.110\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:35:34.661\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:21:37.748\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:35:34.804\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-16 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:21:37.880\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-16 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:35:35.521\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:21:38.515\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_5\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:35:35.641\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-17 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:21:38.621\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-17 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:35:36.312\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-18 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:21:39.220\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-18 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:35:36.968\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-19 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:21:39.827\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-19 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:35:40.752\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-20 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:21:43.477\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-20 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -2805,10 +2805,10 @@
    "id": "2b4100d8",
    "metadata": {
     "papermill": {
-     "duration": 0.017473,
-     "end_time": "2026-05-19T21:36:02.622017+00:00",
+     "duration": 0.018874,
+     "end_time": "2026-05-20T16:22:04.237589+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:36:02.604544+00:00",
+     "start_time": "2026-05-20T16:22:04.218715+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2828,16 +2828,16 @@
    "id": "7763ecdd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:36:02.661744Z",
-     "iopub.status.busy": "2026-05-19T21:36:02.661471Z",
-     "iopub.status.idle": "2026-05-19T21:36:12.409878Z",
-     "shell.execute_reply": "2026-05-19T21:36:12.408897Z"
+     "iopub.execute_input": "2026-05-20T16:22:04.273944Z",
+     "iopub.status.busy": "2026-05-20T16:22:04.273733Z",
+     "iopub.status.idle": "2026-05-20T16:22:36.488810Z",
+     "shell.execute_reply": "2026-05-20T16:22:36.487803Z"
     },
     "papermill": {
-     "duration": 9.768581,
-     "end_time": "2026-05-19T21:36:12.410800+00:00",
+     "duration": 32.234596,
+     "end_time": "2026-05-20T16:22:36.489778+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:36:02.642219+00:00",
+     "start_time": "2026-05-20T16:22:04.255182+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2846,7 +2846,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4f480ba1765e4e60b84634ce0bc1f630",
+       "model_id": "406c2435c70044009e294e809dd659b4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2861,14 +2861,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:36:02.679\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-21 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:22:04.288\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-21 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:36:10.145\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-22 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:22:10.994\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_5\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-22 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -3058,179 +3058,43 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 573.453375,
-   "end_time": "2026-05-19T21:36:13.350358+00:00",
+   "duration": 570.075172,
+   "end_time": "2026-05-20T16:22:37.226893+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "/mnt/share/homes/hjafari/repos/vivarium_gates_mncnh/tests/model_notebooks/interactive/branch_smoke_checks_aph_pph.ipynb",
    "output_path": "/mnt/share/homes/hjafari/repos/vivarium_gates_mncnh/tests/model_notebooks/interactive/executed/branch_smoke_checks_aph_pph.ipynb",
    "parameters": {},
-   "start_time": "2026-05-19T21:26:39.896983+00:00",
+   "start_time": "2026-05-20T16:13:07.151721+00:00",
    "version": "2.7.0"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "00c27a50131744f28b1c6fa19fadc590": {
-      "model_module": "@jupyter-widgets/base",
+     "020d61750f894f5089018171bbd3bdd5": {
+      "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
+      "model_name": "HTMLModel",
       "state": {
-       "_model_module": "@jupyter-widgets/base",
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
        "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
+       "_model_name": "HTMLModel",
        "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
+       "_view_module": "@jupyter-widgets/controls",
        "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_be31c330c522448eba99194e570ec6c7",
+       "placeholder": "​",
+       "style": "IPY_MODEL_f51c6d9b3d1e41339210a26577ac9ef8",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Step: 15"
       }
      },
-     "0154479b8abf4481b65ccc7e61502a57": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "075c2c609a9b47c7a4ea410e72e88d16": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "0fd25d19d49f4f8f8582fdf4b406472f": {
+     "0a9a50d7428d4157bb2c964f40e594a2": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "VBoxModel",
@@ -3245,15 +3109,15 @@
        "_view_name": "VBoxView",
        "box_style": "",
        "children": [
-        "IPY_MODEL_2a62ae1875ed48f28760c167cedca6dc",
-        "IPY_MODEL_b9000ee7dc9542dabf90c9903ac45697"
+        "IPY_MODEL_2e6dd05053b44bf29ffb5ee10a57909e",
+        "IPY_MODEL_47f29dbab48f445ba4786f5e5dba50c1"
        ],
-       "layout": "IPY_MODEL_9529883d457347bbab551559413a456d",
+       "layout": "IPY_MODEL_957cdc189622402e8538def77a146d6a",
        "tabbable": null,
        "tooltip": null
       }
      },
-     "1099ef3cfe154d3f83700d849adc3c51": {
+     "0c0367b356eb4228ace5ad628fc1bd6a": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -3306,145 +3170,7 @@
        "width": null
       }
      },
-     "10b773d48b6e4d588cb48409a1cda5c9": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "ProgressStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "bar_color": null,
-       "description_width": ""
-      }
-     },
-     "168f5334fe18460287a3af18c4e61c57": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "1f49f4873ae34063b61cc9b8cf2a9dfd": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "20621e1264a540999c844ff8c679dff8": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "ProgressStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "bar_color": null,
-       "description_width": ""
-      }
-     },
-     "20838a9a24ed4cae9fbe2b8acd3fe070": {
+     "0cd37b18405d40a7ae79cc3373f05d28": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HTMLStyleModel",
@@ -3462,113 +3188,7 @@
        "text_color": null
       }
      },
-     "275774a22694473db4eb42963638c784": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "289fb930196d47528da57910a3f456ec": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "2a5a3ee86d3d46489496c58c463ae5aa": {
+     "0d918dd77d414880b18b91ea9c5f30ac": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HTMLModel",
@@ -3583,261 +3203,15 @@
        "_view_name": "HTMLView",
        "description": "",
        "description_allow_html": false,
-       "layout": "IPY_MODEL_2d7b4a1dec9b42f09c81db743ace2831",
+       "layout": "IPY_MODEL_cdad056d7c5e44c9bafd98eed709333d",
        "placeholder": "​",
-       "style": "IPY_MODEL_ec93dab745f2448aab163daee9e72465",
-       "tabbable": null,
-       "tooltip": null,
-       "value": "Step: 15"
-      }
-     },
-     "2a62ae1875ed48f28760c167cedca6dc": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_168f5334fe18460287a3af18c4e61c57",
-       "placeholder": "​",
-       "style": "IPY_MODEL_84185398248b4166b6156f452c2ff39f",
-       "tabbable": null,
-       "tooltip": null,
-       "value": "Step: 15"
-      }
-     },
-     "2d52d7df1a9b434a8c15235dee4cdcea": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "background": null,
-       "description_width": "",
-       "font_size": null,
-       "text_color": null
-      }
-     },
-     "2d7b4a1dec9b42f09c81db743ace2831": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "2e734aa909534d9482a2933be6c94b00": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "IntProgressModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "IntProgressModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "ProgressView",
-       "bar_style": "success",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_289fb930196d47528da57910a3f456ec",
-       "max": 15,
-       "min": 0,
-       "orientation": "horizontal",
-       "style": "IPY_MODEL_a7ea49ffc9c64e5da67e042eaf309193",
-       "tabbable": null,
-       "tooltip": null,
-       "value": 15
-      }
-     },
-     "34361f29cb644a9aaeb755b51f799cca": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "VBoxModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "VBoxModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "VBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_2a5a3ee86d3d46489496c58c463ae5aa",
-        "IPY_MODEL_a8d4f0d63a9a4814a0d00bb1731ad58b"
-       ],
-       "layout": "IPY_MODEL_1099ef3cfe154d3f83700d849adc3c51",
-       "tabbable": null,
-       "tooltip": null
-      }
-     },
-     "3bcd3a951288427c94aed222a9576e4b": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "VBoxModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "VBoxModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "VBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_3e142c1bfb234eb6907473fa09b3c725",
-        "IPY_MODEL_bcdc24de05db4ed2859700223699f2b9"
-       ],
-       "layout": "IPY_MODEL_d5f55c0cdd974feeb5a1c98f95b0056e",
-       "tabbable": null,
-       "tooltip": null
-      }
-     },
-     "3c23bc4b5cc940f4877131f092e18100": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "ProgressStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "bar_color": null,
-       "description_width": ""
-      }
-     },
-     "3da95e121c214dce8c9f3023eb8627e7": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_5631ca69158f480cb069a94ee37a9f3c",
-       "placeholder": "​",
-       "style": "IPY_MODEL_686af30a0b2c4974b59d24af7357708a",
+       "style": "IPY_MODEL_2d1b0742ff6b4131b58c69f56bfdc4b5",
        "tabbable": null,
        "tooltip": null,
        "value": "Step: 2"
       }
      },
-     "3e142c1bfb234eb6907473fa09b3c725": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_806bd99812c3438c91fd43e13f496ab1",
-       "placeholder": "​",
-       "style": "IPY_MODEL_2d52d7df1a9b434a8c15235dee4cdcea",
-       "tabbable": null,
-       "tooltip": null,
-       "value": "Step: 20"
-      }
-     },
-     "4c8232540785454f85b6b4e8348afc0b": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "background": null,
-       "description_width": "",
-       "font_size": null,
-       "text_color": null
-      }
-     },
-     "4f480ba1765e4e60b84634ce0bc1f630": {
+     "124be4dbd6fb4ef2bc996a1cb555d874": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "VBoxModel",
@@ -3852,392 +3226,15 @@
        "_view_name": "VBoxView",
        "box_style": "",
        "children": [
-        "IPY_MODEL_3da95e121c214dce8c9f3023eb8627e7",
-        "IPY_MODEL_bb681a34a345432583d8d11dd893d470"
+        "IPY_MODEL_2873c4b336d2406e91f2b12caa68b3a6",
+        "IPY_MODEL_864af82c7cdf46b5bb5e2d0d487d62c3"
        ],
-       "layout": "IPY_MODEL_00c27a50131744f28b1c6fa19fadc590",
+       "layout": "IPY_MODEL_26b5c20eaef54c43ac11600513eec643",
        "tabbable": null,
        "tooltip": null
       }
      },
-     "5631ca69158f480cb069a94ee37a9f3c": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "686af30a0b2c4974b59d24af7357708a": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "background": null,
-       "description_width": "",
-       "font_size": null,
-       "text_color": null
-      }
-     },
-     "6f03015046b24a82b19a015fd80eea64": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "73441cbe24a947cb9fc101bc64509a63": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "7580599b8e0b497a8dee166ac65c575e": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "806bd99812c3438c91fd43e13f496ab1": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "84185398248b4166b6156f452c2ff39f": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "background": null,
-       "description_width": "",
-       "font_size": null,
-       "text_color": null
-      }
-     },
-     "8b996b14b3774488aaed7546155e26ad": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_6f03015046b24a82b19a015fd80eea64",
-       "placeholder": "​",
-       "style": "IPY_MODEL_4c8232540785454f85b6b4e8348afc0b",
-       "tabbable": null,
-       "tooltip": null,
-       "value": "Step: 19"
-      }
-     },
-     "9529883d457347bbab551559413a456d": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "970c215b585e457684ba881df1eadd76": {
+     "1c4dc2ca0a0c4e21bc67a0204aba9f42": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "VBoxModel",
@@ -4252,31 +3249,15 @@
        "_view_name": "VBoxView",
        "box_style": "",
        "children": [
-        "IPY_MODEL_8b996b14b3774488aaed7546155e26ad",
-        "IPY_MODEL_ae2a790b595c478ba8cd450432361ff8"
+        "IPY_MODEL_020d61750f894f5089018171bbd3bdd5",
+        "IPY_MODEL_38f2dcdcd6654f628cbfd2ba1b391550"
        ],
-       "layout": "IPY_MODEL_f46b1da1030e4cecbe942b9369fb4768",
+       "layout": "IPY_MODEL_407015ee78a043a79c95af4fefdd9abf",
        "tabbable": null,
        "tooltip": null
       }
      },
-     "a7ea49ffc9c64e5da67e042eaf309193": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "ProgressStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "bar_color": null,
-       "description_width": ""
-      }
-     },
-     "a8d4f0d63a9a4814a0d00bb1731ad58b": {
+     "1f9dbfd37e8e465d92b80d3aa3559c2c": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "IntProgressModel",
@@ -4292,305 +3273,17 @@
        "bar_style": "success",
        "description": "",
        "description_allow_html": false,
-       "layout": "IPY_MODEL_ade09940af724c828113ac17b1281e28",
-       "max": 15,
-       "min": 0,
-       "orientation": "horizontal",
-       "style": "IPY_MODEL_aabe618feb3f4e7e89421024ec7ec53b",
-       "tabbable": null,
-       "tooltip": null,
-       "value": 15
-      }
-     },
-     "aabe618feb3f4e7e89421024ec7ec53b": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "ProgressStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "bar_color": null,
-       "description_width": ""
-      }
-     },
-     "ade09940af724c828113ac17b1281e28": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "ae2a790b595c478ba8cd450432361ff8": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "IntProgressModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "IntProgressModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "ProgressView",
-       "bar_style": "success",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_73441cbe24a947cb9fc101bc64509a63",
-       "max": 19,
-       "min": 0,
-       "orientation": "horizontal",
-       "style": "IPY_MODEL_10b773d48b6e4d588cb48409a1cda5c9",
-       "tabbable": null,
-       "tooltip": null,
-       "value": 19
-      }
-     },
-     "b9000ee7dc9542dabf90c9903ac45697": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "IntProgressModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "IntProgressModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "ProgressView",
-       "bar_style": "success",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_7580599b8e0b497a8dee166ac65c575e",
-       "max": 15,
-       "min": 0,
-       "orientation": "horizontal",
-       "style": "IPY_MODEL_cc0e4fc5e92a4d018f7e14906e704f84",
-       "tabbable": null,
-       "tooltip": null,
-       "value": 15
-      }
-     },
-     "bb681a34a345432583d8d11dd893d470": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "IntProgressModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "IntProgressModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "ProgressView",
-       "bar_style": "success",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_075c2c609a9b47c7a4ea410e72e88d16",
+       "layout": "IPY_MODEL_abb98d105ffa40bd866af46514711578",
        "max": 2,
        "min": 0,
        "orientation": "horizontal",
-       "style": "IPY_MODEL_20621e1264a540999c844ff8c679dff8",
+       "style": "IPY_MODEL_a57216b6ce3e420cbb28bd14626f7e88",
        "tabbable": null,
        "tooltip": null,
        "value": 2
       }
      },
-     "bc4448da66f74f199671d6cacfac52ef": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "VBoxModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "VBoxModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "VBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_d2edb371ea8d4555966bd46a1cd25b2a",
-        "IPY_MODEL_2e734aa909534d9482a2933be6c94b00"
-       ],
-       "layout": "IPY_MODEL_1f49f4873ae34063b61cc9b8cf2a9dfd",
-       "tabbable": null,
-       "tooltip": null
-      }
-     },
-     "bcdc24de05db4ed2859700223699f2b9": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "IntProgressModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "IntProgressModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "ProgressView",
-       "bar_style": "success",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_0154479b8abf4481b65ccc7e61502a57",
-       "max": 20,
-       "min": 0,
-       "orientation": "horizontal",
-       "style": "IPY_MODEL_3c23bc4b5cc940f4877131f092e18100",
-       "tabbable": null,
-       "tooltip": null,
-       "value": 20
-      }
-     },
-     "cc0e4fc5e92a4d018f7e14906e704f84": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "ProgressStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "bar_color": null,
-       "description_width": ""
-      }
-     },
-     "d2edb371ea8d4555966bd46a1cd25b2a": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_275774a22694473db4eb42963638c784",
-       "placeholder": "​",
-       "style": "IPY_MODEL_20838a9a24ed4cae9fbe2b8acd3fe070",
-       "tabbable": null,
-       "tooltip": null,
-       "value": "Step: 15"
-      }
-     },
-     "d5f55c0cdd974feeb5a1c98f95b0056e": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "ec93dab745f2448aab163daee9e72465": {
+     "208265fa07164fa58d67d87b0816870c": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HTMLStyleModel",
@@ -4608,7 +3301,7 @@
        "text_color": null
       }
      },
-     "f46b1da1030e4cecbe942b9369fb4768": {
+     "22ce4c1ff2fc4ceeb2ac7580ffdb03b7": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -4659,6 +3352,1313 @@
        "top": null,
        "visibility": null,
        "width": null
+      }
+     },
+     "26b5c20eaef54c43ac11600513eec643": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "2873c4b336d2406e91f2b12caa68b3a6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_e2e3e0a1ee0440049e6901e86ab5fbc4",
+       "placeholder": "​",
+       "style": "IPY_MODEL_f4465e037a0047f69cdfee2fe89d0ccf",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Step: 19"
+      }
+     },
+     "2d1b0742ff6b4131b58c69f56bfdc4b5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "2d5cd621317e48b99dace34e00aced75": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "2e6dd05053b44bf29ffb5ee10a57909e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_2d5cd621317e48b99dace34e00aced75",
+       "placeholder": "​",
+       "style": "IPY_MODEL_78b4d198bc8842529d5b6c1bf856063c",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Step: 15"
+      }
+     },
+     "38f2dcdcd6654f628cbfd2ba1b391550": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "IntProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_4514d96bed2b406ea16525287233f4ac",
+       "max": 15,
+       "min": 0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_8c8d1a89424742a393f629967c059c91",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 15
+      }
+     },
+     "3f60885c8bab4798aeff3104331961e0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "406c2435c70044009e294e809dd659b4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "VBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "VBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_0d918dd77d414880b18b91ea9c5f30ac",
+        "IPY_MODEL_1f9dbfd37e8e465d92b80d3aa3559c2c"
+       ],
+       "layout": "IPY_MODEL_a1f6e3765b194b5fa32fb88fb20976f3",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "407015ee78a043a79c95af4fefdd9abf": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "4514d96bed2b406ea16525287233f4ac": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "46f1e6361533451380b4e8f99e1d4efe": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "IntProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_4dc3f4730e5b457c822315faa496025e",
+       "max": 15,
+       "min": 0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_3f60885c8bab4798aeff3104331961e0",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 15
+      }
+     },
+     "47f29dbab48f445ba4786f5e5dba50c1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "IntProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_0c0367b356eb4228ace5ad628fc1bd6a",
+       "max": 15,
+       "min": 0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_e4536914e8b84f00b487c2d1c8072ac6",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 15
+      }
+     },
+     "4a0529fa4fdd4801b17216138c0af6a2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "4dc3f4730e5b457c822315faa496025e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "63b21c3ed4034759ad111f9891c21a42": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "654ae38a4f234d91901f94316453596a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "IntProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_c744618dec0a4c1989141ecd8111f8e0",
+       "max": 20,
+       "min": 0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_63b21c3ed4034759ad111f9891c21a42",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 20
+      }
+     },
+     "6a09e86f297a423c982450af1a2f0d23": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "78b4d198bc8842529d5b6c1bf856063c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "864af82c7cdf46b5bb5e2d0d487d62c3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "IntProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_cb4465cf02684a60a894d7c49f767ccb",
+       "max": 19,
+       "min": 0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_9b92fa4ac94940918d467ca85f062616",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 19
+      }
+     },
+     "86a4d7c5c51745bebd6d4c8c593aba56": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_22ce4c1ff2fc4ceeb2ac7580ffdb03b7",
+       "placeholder": "​",
+       "style": "IPY_MODEL_0cd37b18405d40a7ae79cc3373f05d28",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Step: 20"
+      }
+     },
+     "8c8d1a89424742a393f629967c059c91": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "957cdc189622402e8538def77a146d6a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "9b92fa4ac94940918d467ca85f062616": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "9bc0cb7251ca4faf85ebe7a2dec5a0c7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "VBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "VBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_a0bd10c42d334816b7b063c49cbb4426",
+        "IPY_MODEL_46f1e6361533451380b4e8f99e1d4efe"
+       ],
+       "layout": "IPY_MODEL_dbbfcefced824fa6b9c9d80e152c5df6",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "a0bd10c42d334816b7b063c49cbb4426": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_4a0529fa4fdd4801b17216138c0af6a2",
+       "placeholder": "​",
+       "style": "IPY_MODEL_208265fa07164fa58d67d87b0816870c",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Step: 15"
+      }
+     },
+     "a1f6e3765b194b5fa32fb88fb20976f3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "a57216b6ce3e420cbb28bd14626f7e88": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "abb98d105ffa40bd866af46514711578": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "be31c330c522448eba99194e570ec6c7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "c744618dec0a4c1989141ecd8111f8e0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "cb4465cf02684a60a894d7c49f767ccb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "cdad056d7c5e44c9bafd98eed709333d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "dbbfcefced824fa6b9c9d80e152c5df6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "dc190b979f3940dc900d6c7cd367a05b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "VBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "VBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_86a4d7c5c51745bebd6d4c8c593aba56",
+        "IPY_MODEL_654ae38a4f234d91901f94316453596a"
+       ],
+       "layout": "IPY_MODEL_6a09e86f297a423c982450af1a2f0d23",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "e2e3e0a1ee0440049e6901e86ab5fbc4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "e4536914e8b84f00b487c2d1c8072ac6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "f4465e037a0047f69cdfee2fe89d0ccf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "f51c6d9b3d1e41339210a26577ac9ef8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
       }
      }
     },

--- a/tests/model_notebooks/interactive/executed/interactive_simulation_gestational_age.ipynb
+++ b/tests/model_notebooks/interactive/executed/interactive_simulation_gestational_age.ipynb
@@ -3,19 +3,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "5c417d67",
+   "id": "ce56c6ec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:36:18.954281Z",
-     "iopub.status.busy": "2026-05-19T21:36:18.954021Z",
-     "iopub.status.idle": "2026-05-19T21:36:23.707677Z",
-     "shell.execute_reply": "2026-05-19T21:36:23.706435Z"
+     "iopub.execute_input": "2026-05-20T16:22:40.397664Z",
+     "iopub.status.busy": "2026-05-20T16:22:40.397477Z",
+     "iopub.status.idle": "2026-05-20T16:22:42.932704Z",
+     "shell.execute_reply": "2026-05-20T16:22:42.930956Z"
     },
     "papermill": {
-     "duration": 4.766477,
-     "end_time": "2026-05-19T21:36:23.709306+00:00",
+     "duration": 2.547885,
+     "end_time": "2026-05-20T16:22:42.933468+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:36:18.942829+00:00",
+     "start_time": "2026-05-20T16:22:40.385583+00:00",
      "status": "completed"
     },
     "tags": []
@@ -29,19 +29,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "945e48e4",
+   "id": "a9ced89f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:36:23.724131Z",
-     "iopub.status.busy": "2026-05-19T21:36:23.723654Z",
-     "iopub.status.idle": "2026-05-19T21:36:25.714186Z",
-     "shell.execute_reply": "2026-05-19T21:36:25.712914Z"
+     "iopub.execute_input": "2026-05-20T16:22:42.947799Z",
+     "iopub.status.busy": "2026-05-20T16:22:42.947412Z",
+     "iopub.status.idle": "2026-05-20T16:22:45.252492Z",
+     "shell.execute_reply": "2026-05-20T16:22:45.249523Z"
     },
     "papermill": {
-     "duration": 1.998276,
-     "end_time": "2026-05-19T21:36:25.715141+00:00",
+     "duration": 2.31422,
+     "end_time": "2026-05-20T16:22:45.254234+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:36:23.716865+00:00",
+     "start_time": "2026-05-20T16:22:42.940014+00:00",
      "status": "completed"
     },
     "tags": []
@@ -74,19 +74,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "7513d245",
+   "id": "fa374606",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:36:25.728492Z",
-     "iopub.status.busy": "2026-05-19T21:36:25.728074Z",
-     "iopub.status.idle": "2026-05-19T21:36:26.690862Z",
-     "shell.execute_reply": "2026-05-19T21:36:26.688779Z"
+     "iopub.execute_input": "2026-05-20T16:22:45.272736Z",
+     "iopub.status.busy": "2026-05-20T16:22:45.272465Z",
+     "iopub.status.idle": "2026-05-20T16:22:46.300706Z",
+     "shell.execute_reply": "2026-05-20T16:22:46.298488Z"
     },
     "papermill": {
-     "duration": 0.971719,
-     "end_time": "2026-05-19T21:36:26.693040+00:00",
+     "duration": 1.038189,
+     "end_time": "2026-05-20T16:22:46.302869+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:36:25.721321+00:00",
+     "start_time": "2026-05-20T16:22:45.264680+00:00",
      "status": "completed"
     },
     "tags": []
@@ -102,7 +102,7 @@
       "vivarium_build_utils==3.2.2\r\n",
       "vivarium_cluster_tools==3.1.4\r\n",
       "vivarium_dependencies==1.0.7\r\n",
-      "-e git+ssh://git@github.com/ihmeuw/vivarium_gates_mncnh.git@14f8fa92ad0d30ff2d378fd8eed994e43c009c98#egg=vivarium_gates_mncnh\r\n",
+      "-e git+ssh://git@github.com/ihmeuw/vivarium_gates_mncnh.git@0096ee26c33ca456df2b51be38ce84948cb6ee28#egg=vivarium_gates_mncnh\r\n",
       "vivarium_gbd_access==5.0.10\r\n",
       "vivarium_inputs==7.2.4\r\n",
       "vivarium_public_health==5.0.2\r\n",
@@ -117,19 +117,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "5ef28e31",
+   "id": "0fef4b57",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:36:26.709742Z",
-     "iopub.status.busy": "2026-05-19T21:36:26.709486Z",
-     "iopub.status.idle": "2026-05-19T21:36:26.714143Z",
-     "shell.execute_reply": "2026-05-19T21:36:26.713073Z"
+     "iopub.execute_input": "2026-05-20T16:22:46.320750Z",
+     "iopub.status.busy": "2026-05-20T16:22:46.320471Z",
+     "iopub.status.idle": "2026-05-20T16:22:46.324796Z",
+     "shell.execute_reply": "2026-05-20T16:22:46.323883Z"
     },
     "papermill": {
-     "duration": 0.012264,
-     "end_time": "2026-05-19T21:36:26.715063+00:00",
+     "duration": 0.012574,
+     "end_time": "2026-05-20T16:22:46.325637+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:36:26.702799+00:00",
+     "start_time": "2026-05-20T16:22:46.313063+00:00",
      "status": "completed"
     },
     "tags": []
@@ -145,19 +145,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "1e7fabc8",
+   "id": "8db51ffa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:36:26.727683Z",
-     "iopub.status.busy": "2026-05-19T21:36:26.727426Z",
-     "iopub.status.idle": "2026-05-19T21:36:29.324293Z",
-     "shell.execute_reply": "2026-05-19T21:36:29.323005Z"
+     "iopub.execute_input": "2026-05-20T16:22:46.339461Z",
+     "iopub.status.busy": "2026-05-20T16:22:46.339227Z",
+     "iopub.status.idle": "2026-05-20T16:22:49.017213Z",
+     "shell.execute_reply": "2026-05-20T16:22:49.016290Z"
     },
     "papermill": {
-     "duration": 2.604175,
-     "end_time": "2026-05-19T21:36:29.325117+00:00",
+     "duration": 2.686223,
+     "end_time": "2026-05-20T16:22:49.018092+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:36:26.720942+00:00",
+     "start_time": "2026-05-20T16:22:46.331869+00:00",
      "status": "completed"
     },
     "tags": []
@@ -194,19 +194,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "6c0a5472",
+   "id": "be5a4b2e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:36:29.338942Z",
-     "iopub.status.busy": "2026-05-19T21:36:29.338645Z",
-     "iopub.status.idle": "2026-05-19T21:36:29.343972Z",
-     "shell.execute_reply": "2026-05-19T21:36:29.342920Z"
+     "iopub.execute_input": "2026-05-20T16:22:49.032744Z",
+     "iopub.status.busy": "2026-05-20T16:22:49.032494Z",
+     "iopub.status.idle": "2026-05-20T16:22:49.037454Z",
+     "shell.execute_reply": "2026-05-20T16:22:49.036514Z"
     },
     "papermill": {
-     "duration": 0.013747,
-     "end_time": "2026-05-19T21:36:29.345235+00:00",
+     "duration": 0.013224,
+     "end_time": "2026-05-20T16:22:49.038360+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:36:29.331488+00:00",
+     "start_time": "2026-05-20T16:22:49.025136+00:00",
      "status": "completed"
     },
     "tags": []
@@ -232,19 +232,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "659c4d57",
+   "id": "c16393f6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:36:29.358336Z",
-     "iopub.status.busy": "2026-05-19T21:36:29.358032Z",
-     "iopub.status.idle": "2026-05-19T21:37:15.745822Z",
-     "shell.execute_reply": "2026-05-19T21:37:15.744630Z"
+     "iopub.execute_input": "2026-05-20T16:22:49.053514Z",
+     "iopub.status.busy": "2026-05-20T16:22:49.052834Z",
+     "iopub.status.idle": "2026-05-20T16:23:34.255178Z",
+     "shell.execute_reply": "2026-05-20T16:23:34.254079Z"
     },
     "papermill": {
-     "duration": 46.395627,
-     "end_time": "2026-05-19T21:37:15.746975+00:00",
+     "duration": 45.211504,
+     "end_time": "2026-05-20T16:23:34.256465+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:36:29.351348+00:00",
+     "start_time": "2026-05-20T16:22:49.044961+00:00",
      "status": "completed"
     },
     "tags": []
@@ -254,147 +254,147 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:36:29.882\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:22:49.344\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:36:29.883\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:22:49.344\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:36:29.884\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:22:49.345\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:37:09.288\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:23:28.182\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:37:09.289\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:23:28.183\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:37:09.468\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:23:28.361\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:37:09.468\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:23:28.361\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:37:09.469\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:23:28.362\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:37:09.470\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:23:28.362\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:37:09.470\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:23:28.363\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:37:09.471\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:23:28.363\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:37:09.471\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:23:28.364\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:37:09.472\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:23:28.364\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:37:09.473\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:23:28.367\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:37:09.473\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:23:28.368\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:37:09.474\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:23:28.368\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:37:09.474\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:23:28.369\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:37:09.479\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:23:28.369\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:37:09.479\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:23:28.370\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:37:09.480\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:23:28.370\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:37:09.480\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
+      "\u001b[32m2026-05-20 09:23:28.371\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
       "['ferritin_screening_coverage', 'hemoglobin_screening_coverage', 'sex']\u001b[0m\n"
      ]
     }
@@ -406,19 +406,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "093d1938",
+   "id": "529cb13a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:37:15.763050Z",
-     "iopub.status.busy": "2026-05-19T21:37:15.762785Z",
-     "iopub.status.idle": "2026-05-19T21:37:15.768662Z",
-     "shell.execute_reply": "2026-05-19T21:37:15.767628Z"
+     "iopub.execute_input": "2026-05-20T16:23:34.272841Z",
+     "iopub.status.busy": "2026-05-20T16:23:34.272564Z",
+     "iopub.status.idle": "2026-05-20T16:23:34.278226Z",
+     "shell.execute_reply": "2026-05-20T16:23:34.277239Z"
     },
     "papermill": {
-     "duration": 0.015104,
-     "end_time": "2026-05-19T21:37:15.769789+00:00",
+     "duration": 0.014937,
+     "end_time": "2026-05-20T16:23:34.279318+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:37:15.754685+00:00",
+     "start_time": "2026-05-20T16:23:34.264381+00:00",
      "status": "completed"
     },
     "tags": []
@@ -443,19 +443,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "72057cd2",
+   "id": "270f6cda",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:37:15.785607Z",
-     "iopub.status.busy": "2026-05-19T21:37:15.785361Z",
-     "iopub.status.idle": "2026-05-19T21:37:15.791308Z",
-     "shell.execute_reply": "2026-05-19T21:37:15.790425Z"
+     "iopub.execute_input": "2026-05-20T16:23:34.295352Z",
+     "iopub.status.busy": "2026-05-20T16:23:34.295101Z",
+     "iopub.status.idle": "2026-05-20T16:23:34.302688Z",
+     "shell.execute_reply": "2026-05-20T16:23:34.301912Z"
     },
     "papermill": {
-     "duration": 0.015285,
-     "end_time": "2026-05-19T21:37:15.792369+00:00",
+     "duration": 0.016894,
+     "end_time": "2026-05-20T16:23:34.303609+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:37:15.777084+00:00",
+     "start_time": "2026-05-20T16:23:34.286715+00:00",
      "status": "completed"
     },
     "tags": []
@@ -479,19 +479,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "8df03113",
+   "id": "ab50fa9a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:37:15.808362Z",
-     "iopub.status.busy": "2026-05-19T21:37:15.808010Z",
-     "iopub.status.idle": "2026-05-19T21:37:30.448416Z",
-     "shell.execute_reply": "2026-05-19T21:37:30.447398Z"
+     "iopub.execute_input": "2026-05-20T16:23:34.320010Z",
+     "iopub.status.busy": "2026-05-20T16:23:34.319796Z",
+     "iopub.status.idle": "2026-05-20T16:23:47.845425Z",
+     "shell.execute_reply": "2026-05-20T16:23:47.843706Z"
     },
     "papermill": {
-     "duration": 14.650055,
-     "end_time": "2026-05-19T21:37:30.449763+00:00",
+     "duration": 13.535164,
+     "end_time": "2026-05-20T16:23:47.846165+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:37:15.799708+00:00",
+     "start_time": "2026-05-20T16:23:34.311001+00:00",
      "status": "completed"
     },
     "tags": []
@@ -508,19 +508,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "91d41fa5",
+   "id": "bfbb6826",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:37:30.466886Z",
-     "iopub.status.busy": "2026-05-19T21:37:30.466632Z",
-     "iopub.status.idle": "2026-05-19T21:39:57.598563Z",
-     "shell.execute_reply": "2026-05-19T21:39:57.597430Z"
+     "iopub.execute_input": "2026-05-20T16:23:47.863131Z",
+     "iopub.status.busy": "2026-05-20T16:23:47.862815Z",
+     "iopub.status.idle": "2026-05-20T16:26:01.800809Z",
+     "shell.execute_reply": "2026-05-20T16:26:01.799574Z"
     },
     "papermill": {
-     "duration": 147.142058,
-     "end_time": "2026-05-19T21:39:57.599796+00:00",
+     "duration": 133.947205,
+     "end_time": "2026-05-20T16:26:01.801719+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:37:30.457738+00:00",
+     "start_time": "2026-05-20T16:23:47.854514+00:00",
      "status": "completed"
     },
     "tags": []
@@ -530,35 +530,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:37:45.094\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:24:01.202\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:38:27.197\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:24:38.839\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:38:46.157\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:24:55.180\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:39:06.117\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:25:13.060\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:39:29.050\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:25:34.662\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
      ]
     }
    ],
@@ -580,19 +580,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "40f13584",
+   "id": "d177bb4b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:39:57.618040Z",
-     "iopub.status.busy": "2026-05-19T21:39:57.617812Z",
-     "iopub.status.idle": "2026-05-19T21:40:11.676952Z",
-     "shell.execute_reply": "2026-05-19T21:40:11.675911Z"
+     "iopub.execute_input": "2026-05-20T16:26:01.819230Z",
+     "iopub.status.busy": "2026-05-20T16:26:01.818899Z",
+     "iopub.status.idle": "2026-05-20T16:26:15.253983Z",
+     "shell.execute_reply": "2026-05-20T16:26:15.252889Z"
     },
     "papermill": {
-     "duration": 14.070397,
-     "end_time": "2026-05-19T21:40:11.679608+00:00",
+     "duration": 13.45303,
+     "end_time": "2026-05-20T16:26:15.263150+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:39:57.609211+00:00",
+     "start_time": "2026-05-20T16:26:01.810120+00:00",
      "status": "completed"
     },
     "tags": []
@@ -751,19 +751,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "da641ed9",
+   "id": "98acea46",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:11.695748Z",
-     "iopub.status.busy": "2026-05-19T21:40:11.695492Z",
-     "iopub.status.idle": "2026-05-19T21:40:11.731010Z",
-     "shell.execute_reply": "2026-05-19T21:40:11.729988Z"
+     "iopub.execute_input": "2026-05-20T16:26:15.279689Z",
+     "iopub.status.busy": "2026-05-20T16:26:15.279496Z",
+     "iopub.status.idle": "2026-05-20T16:26:15.311893Z",
+     "shell.execute_reply": "2026-05-20T16:26:15.310904Z"
     },
     "papermill": {
-     "duration": 0.044798,
-     "end_time": "2026-05-19T21:40:11.732120+00:00",
+     "duration": 0.042153,
+     "end_time": "2026-05-20T16:26:15.312972+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:11.687322+00:00",
+     "start_time": "2026-05-20T16:26:15.270819+00:00",
      "status": "completed"
     },
     "tags": []
@@ -776,19 +776,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "c10f080b",
+   "id": "cd58b9c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:11.749206Z",
-     "iopub.status.busy": "2026-05-19T21:40:11.749000Z",
-     "iopub.status.idle": "2026-05-19T21:40:11.755638Z",
-     "shell.execute_reply": "2026-05-19T21:40:11.754683Z"
+     "iopub.execute_input": "2026-05-20T16:26:15.330743Z",
+     "iopub.status.busy": "2026-05-20T16:26:15.330488Z",
+     "iopub.status.idle": "2026-05-20T16:26:15.336281Z",
+     "shell.execute_reply": "2026-05-20T16:26:15.335172Z"
     },
     "papermill": {
-     "duration": 0.016443,
-     "end_time": "2026-05-19T21:40:11.756661+00:00",
+     "duration": 0.016656,
+     "end_time": "2026-05-20T16:26:15.337502+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:11.740218+00:00",
+     "start_time": "2026-05-20T16:26:15.320846+00:00",
      "status": "completed"
     },
     "tags": []
@@ -804,19 +804,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "9c5c6a01",
+   "id": "ef3836ff",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:11.773794Z",
-     "iopub.status.busy": "2026-05-19T21:40:11.773528Z",
-     "iopub.status.idle": "2026-05-19T21:40:11.777985Z",
-     "shell.execute_reply": "2026-05-19T21:40:11.776845Z"
+     "iopub.execute_input": "2026-05-20T16:26:15.354776Z",
+     "iopub.status.busy": "2026-05-20T16:26:15.354557Z",
+     "iopub.status.idle": "2026-05-20T16:26:15.358885Z",
+     "shell.execute_reply": "2026-05-20T16:26:15.358115Z"
     },
     "papermill": {
-     "duration": 0.01435,
-     "end_time": "2026-05-19T21:40:11.778801+00:00",
+     "duration": 0.014167,
+     "end_time": "2026-05-20T16:26:15.359765+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:11.764451+00:00",
+     "start_time": "2026-05-20T16:26:15.345598+00:00",
      "status": "completed"
     },
     "tags": []
@@ -833,19 +833,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "ab90f7bf",
+   "id": "29442412",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:11.796150Z",
-     "iopub.status.busy": "2026-05-19T21:40:11.795798Z",
-     "iopub.status.idle": "2026-05-19T21:40:11.824217Z",
-     "shell.execute_reply": "2026-05-19T21:40:11.822970Z"
+     "iopub.execute_input": "2026-05-20T16:26:15.377343Z",
+     "iopub.status.busy": "2026-05-20T16:26:15.377132Z",
+     "iopub.status.idle": "2026-05-20T16:26:15.406018Z",
+     "shell.execute_reply": "2026-05-20T16:26:15.405015Z"
     },
     "papermill": {
-     "duration": 0.038803,
-     "end_time": "2026-05-19T21:40:11.825324+00:00",
+     "duration": 0.039133,
+     "end_time": "2026-05-20T16:26:15.406968+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:11.786521+00:00",
+     "start_time": "2026-05-20T16:26:15.367835+00:00",
      "status": "completed"
     },
     "tags": []
@@ -877,19 +877,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "19efea55",
+   "id": "456e5753",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:11.842207Z",
-     "iopub.status.busy": "2026-05-19T21:40:11.841897Z",
-     "iopub.status.idle": "2026-05-19T21:40:11.863248Z",
-     "shell.execute_reply": "2026-05-19T21:40:11.862107Z"
+     "iopub.execute_input": "2026-05-20T16:26:15.425128Z",
+     "iopub.status.busy": "2026-05-20T16:26:15.424853Z",
+     "iopub.status.idle": "2026-05-20T16:26:15.446563Z",
+     "shell.execute_reply": "2026-05-20T16:26:15.445718Z"
     },
     "papermill": {
-     "duration": 0.030217,
-     "end_time": "2026-05-19T21:40:11.863941+00:00",
+     "duration": 0.031639,
+     "end_time": "2026-05-20T16:26:15.447417+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:11.833724+00:00",
+     "start_time": "2026-05-20T16:26:15.415778+00:00",
      "status": "completed"
     },
     "tags": []
@@ -921,19 +921,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "869e82b0",
+   "id": "24ecf6a6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:11.881395Z",
-     "iopub.status.busy": "2026-05-19T21:40:11.881160Z",
-     "iopub.status.idle": "2026-05-19T21:40:11.998648Z",
-     "shell.execute_reply": "2026-05-19T21:40:11.997573Z"
+     "iopub.execute_input": "2026-05-20T16:26:15.465023Z",
+     "iopub.status.busy": "2026-05-20T16:26:15.464726Z",
+     "iopub.status.idle": "2026-05-20T16:26:15.583763Z",
+     "shell.execute_reply": "2026-05-20T16:26:15.582707Z"
     },
     "papermill": {
-     "duration": 0.127451,
-     "end_time": "2026-05-19T21:40:11.999473+00:00",
+     "duration": 0.128774,
+     "end_time": "2026-05-20T16:26:15.584443+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:11.872022+00:00",
+     "start_time": "2026-05-20T16:26:15.455669+00:00",
      "status": "completed"
     },
     "tags": []
@@ -962,19 +962,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "3cbc2409",
+   "id": "4e3acdc8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:12.017725Z",
-     "iopub.status.busy": "2026-05-19T21:40:12.017494Z",
-     "iopub.status.idle": "2026-05-19T21:40:12.038388Z",
-     "shell.execute_reply": "2026-05-19T21:40:12.037268Z"
+     "iopub.execute_input": "2026-05-20T16:26:15.601713Z",
+     "iopub.status.busy": "2026-05-20T16:26:15.601497Z",
+     "iopub.status.idle": "2026-05-20T16:26:15.621552Z",
+     "shell.execute_reply": "2026-05-20T16:26:15.620434Z"
     },
     "papermill": {
-     "duration": 0.030974,
-     "end_time": "2026-05-19T21:40:12.039079+00:00",
+     "duration": 0.029658,
+     "end_time": "2026-05-20T16:26:15.622368+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:12.008105+00:00",
+     "start_time": "2026-05-20T16:26:15.592710+00:00",
      "status": "completed"
     },
     "tags": []
@@ -989,19 +989,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "5049182b",
+   "id": "8c72a02d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:12.056718Z",
-     "iopub.status.busy": "2026-05-19T21:40:12.056499Z",
-     "iopub.status.idle": "2026-05-19T21:40:12.073516Z",
-     "shell.execute_reply": "2026-05-19T21:40:12.072687Z"
+     "iopub.execute_input": "2026-05-20T16:26:15.640941Z",
+     "iopub.status.busy": "2026-05-20T16:26:15.640702Z",
+     "iopub.status.idle": "2026-05-20T16:26:15.657458Z",
+     "shell.execute_reply": "2026-05-20T16:26:15.656355Z"
     },
     "papermill": {
-     "duration": 0.027051,
-     "end_time": "2026-05-19T21:40:12.074517+00:00",
+     "duration": 0.027034,
+     "end_time": "2026-05-20T16:26:15.658182+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:12.047466+00:00",
+     "start_time": "2026-05-20T16:26:15.631148+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1015,13 +1015,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1d59173b",
+   "id": "fdd155e9",
    "metadata": {
     "papermill": {
-     "duration": 0.007963,
-     "end_time": "2026-05-19T21:40:12.090536+00:00",
+     "duration": 0.008807,
+     "end_time": "2026-05-20T16:26:15.677082+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:12.082573+00:00",
+     "start_time": "2026-05-20T16:26:15.668275+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1088,14 +1088,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 236.03872,
-   "end_time": "2026-05-19T21:40:12.718518+00:00",
+   "duration": 217.288969,
+   "end_time": "2026-05-20T16:26:16.203063+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "/mnt/share/homes/hjafari/repos/vivarium_gates_mncnh/tests/model_notebooks/interactive/interactive_simulation_gestational_age.ipynb",
    "output_path": "/mnt/share/homes/hjafari/repos/vivarium_gates_mncnh/tests/model_notebooks/interactive/executed/interactive_simulation_gestational_age.ipynb",
    "parameters": {},
-   "start_time": "2026-05-19T21:36:16.679798+00:00",
+   "start_time": "2026-05-20T16:22:38.914094+00:00",
    "version": "2.7.0"
   }
  },

--- a/tests/model_notebooks/interactive/executed/interactive_simulation_gestational_age.ipynb
+++ b/tests/model_notebooks/interactive/executed/interactive_simulation_gestational_age.ipynb
@@ -3,19 +3,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "ce56c6ec",
+   "id": "7db85ed8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:22:40.397664Z",
-     "iopub.status.busy": "2026-05-20T16:22:40.397477Z",
-     "iopub.status.idle": "2026-05-20T16:22:42.932704Z",
-     "shell.execute_reply": "2026-05-20T16:22:42.930956Z"
+     "iopub.execute_input": "2026-05-20T18:18:09.281005Z",
+     "iopub.status.busy": "2026-05-20T18:18:09.280735Z",
+     "iopub.status.idle": "2026-05-20T18:18:11.700603Z",
+     "shell.execute_reply": "2026-05-20T18:18:11.699761Z"
     },
     "papermill": {
-     "duration": 2.547885,
-     "end_time": "2026-05-20T16:22:42.933468+00:00",
+     "duration": 2.43248,
+     "end_time": "2026-05-20T18:18:11.701863+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:22:40.385583+00:00",
+     "start_time": "2026-05-20T18:18:09.269383+00:00",
      "status": "completed"
     },
     "tags": []
@@ -29,19 +29,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "a9ced89f",
+   "id": "3a78ccc0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:22:42.947799Z",
-     "iopub.status.busy": "2026-05-20T16:22:42.947412Z",
-     "iopub.status.idle": "2026-05-20T16:22:45.252492Z",
-     "shell.execute_reply": "2026-05-20T16:22:45.249523Z"
+     "iopub.execute_input": "2026-05-20T18:18:11.717116Z",
+     "iopub.status.busy": "2026-05-20T18:18:11.716744Z",
+     "iopub.status.idle": "2026-05-20T18:18:13.772144Z",
+     "shell.execute_reply": "2026-05-20T18:18:13.768753Z"
     },
     "papermill": {
-     "duration": 2.31422,
-     "end_time": "2026-05-20T16:22:45.254234+00:00",
+     "duration": 2.06419,
+     "end_time": "2026-05-20T18:18:13.773987+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:22:42.940014+00:00",
+     "start_time": "2026-05-20T18:18:11.709797+00:00",
      "status": "completed"
     },
     "tags": []
@@ -74,19 +74,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "fa374606",
+   "id": "696bc648",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:22:45.272736Z",
-     "iopub.status.busy": "2026-05-20T16:22:45.272465Z",
-     "iopub.status.idle": "2026-05-20T16:22:46.300706Z",
-     "shell.execute_reply": "2026-05-20T16:22:46.298488Z"
+     "iopub.execute_input": "2026-05-20T18:18:13.789967Z",
+     "iopub.status.busy": "2026-05-20T18:18:13.789628Z",
+     "iopub.status.idle": "2026-05-20T18:18:14.792497Z",
+     "shell.execute_reply": "2026-05-20T18:18:14.789336Z"
     },
     "papermill": {
-     "duration": 1.038189,
-     "end_time": "2026-05-20T16:22:46.302869+00:00",
+     "duration": 1.012013,
+     "end_time": "2026-05-20T18:18:14.794229+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:22:45.264680+00:00",
+     "start_time": "2026-05-20T18:18:13.782216+00:00",
      "status": "completed"
     },
     "tags": []
@@ -102,7 +102,7 @@
       "vivarium_build_utils==3.2.2\r\n",
       "vivarium_cluster_tools==3.1.4\r\n",
       "vivarium_dependencies==1.0.7\r\n",
-      "-e git+ssh://git@github.com/ihmeuw/vivarium_gates_mncnh.git@0096ee26c33ca456df2b51be38ce84948cb6ee28#egg=vivarium_gates_mncnh\r\n",
+      "-e git+ssh://git@github.com/ihmeuw/vivarium_gates_mncnh.git@963245346ffafd6c4eed18ce4bd97d1394635683#egg=vivarium_gates_mncnh\r\n",
       "vivarium_gbd_access==5.0.10\r\n",
       "vivarium_inputs==7.2.4\r\n",
       "vivarium_public_health==5.0.2\r\n",
@@ -117,19 +117,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "0fef4b57",
+   "id": "0e113e4f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:22:46.320750Z",
-     "iopub.status.busy": "2026-05-20T16:22:46.320471Z",
-     "iopub.status.idle": "2026-05-20T16:22:46.324796Z",
-     "shell.execute_reply": "2026-05-20T16:22:46.323883Z"
+     "iopub.execute_input": "2026-05-20T18:18:14.809845Z",
+     "iopub.status.busy": "2026-05-20T18:18:14.809598Z",
+     "iopub.status.idle": "2026-05-20T18:18:14.813938Z",
+     "shell.execute_reply": "2026-05-20T18:18:14.813040Z"
     },
     "papermill": {
-     "duration": 0.012574,
-     "end_time": "2026-05-20T16:22:46.325637+00:00",
+     "duration": 0.012445,
+     "end_time": "2026-05-20T18:18:14.814715+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:22:46.313063+00:00",
+     "start_time": "2026-05-20T18:18:14.802270+00:00",
      "status": "completed"
     },
     "tags": []
@@ -145,19 +145,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "8db51ffa",
+   "id": "26f74dda",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:22:46.339461Z",
-     "iopub.status.busy": "2026-05-20T16:22:46.339227Z",
-     "iopub.status.idle": "2026-05-20T16:22:49.017213Z",
-     "shell.execute_reply": "2026-05-20T16:22:49.016290Z"
+     "iopub.execute_input": "2026-05-20T18:18:14.828242Z",
+     "iopub.status.busy": "2026-05-20T18:18:14.827944Z",
+     "iopub.status.idle": "2026-05-20T18:18:17.469235Z",
+     "shell.execute_reply": "2026-05-20T18:18:17.468062Z"
     },
     "papermill": {
-     "duration": 2.686223,
-     "end_time": "2026-05-20T16:22:49.018092+00:00",
+     "duration": 2.648998,
+     "end_time": "2026-05-20T18:18:17.469937+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:22:46.331869+00:00",
+     "start_time": "2026-05-20T18:18:14.820939+00:00",
      "status": "completed"
     },
     "tags": []
@@ -194,19 +194,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "be5a4b2e",
+   "id": "33abce23",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:22:49.032744Z",
-     "iopub.status.busy": "2026-05-20T16:22:49.032494Z",
-     "iopub.status.idle": "2026-05-20T16:22:49.037454Z",
-     "shell.execute_reply": "2026-05-20T16:22:49.036514Z"
+     "iopub.execute_input": "2026-05-20T18:18:17.483804Z",
+     "iopub.status.busy": "2026-05-20T18:18:17.483494Z",
+     "iopub.status.idle": "2026-05-20T18:18:17.489329Z",
+     "shell.execute_reply": "2026-05-20T18:18:17.488421Z"
     },
     "papermill": {
-     "duration": 0.013224,
-     "end_time": "2026-05-20T16:22:49.038360+00:00",
+     "duration": 0.013852,
+     "end_time": "2026-05-20T18:18:17.490244+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:22:49.025136+00:00",
+     "start_time": "2026-05-20T18:18:17.476392+00:00",
      "status": "completed"
     },
     "tags": []
@@ -232,19 +232,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "c16393f6",
+   "id": "d5b5fb38",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:22:49.053514Z",
-     "iopub.status.busy": "2026-05-20T16:22:49.052834Z",
-     "iopub.status.idle": "2026-05-20T16:23:34.255178Z",
-     "shell.execute_reply": "2026-05-20T16:23:34.254079Z"
+     "iopub.execute_input": "2026-05-20T18:18:17.504285Z",
+     "iopub.status.busy": "2026-05-20T18:18:17.504040Z",
+     "iopub.status.idle": "2026-05-20T18:19:02.719715Z",
+     "shell.execute_reply": "2026-05-20T18:19:02.718115Z"
     },
     "papermill": {
-     "duration": 45.211504,
-     "end_time": "2026-05-20T16:23:34.256465+00:00",
+     "duration": 45.224007,
+     "end_time": "2026-05-20T18:19:02.720588+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:22:49.044961+00:00",
+     "start_time": "2026-05-20T18:18:17.496581+00:00",
      "status": "completed"
     },
     "tags": []
@@ -254,147 +254,147 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:22:49.344\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:18:17.773\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:22:49.344\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:18:17.774\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:22:49.345\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:18:17.776\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:23:28.182\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:18:56.429\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:23:28.183\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:18:56.430\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:23:28.361\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:18:56.610\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:23:28.361\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:18:56.611\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:23:28.362\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:18:56.611\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:23:28.362\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:18:56.612\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:23:28.363\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:18:56.612\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:23:28.363\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:18:56.613\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:23:28.364\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:18:56.613\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:23:28.364\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:18:56.614\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:23:28.367\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:18:56.615\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:23:28.368\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:18:56.615\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:23:28.368\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:18:56.616\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:23:28.369\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:18:56.616\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:23:28.369\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:18:56.617\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:23:28.370\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:18:56.618\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:23:28.370\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:18:56.618\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:23:28.371\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
+      "\u001b[32m2026-05-20 11:18:56.619\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
       "['ferritin_screening_coverage', 'hemoglobin_screening_coverage', 'sex']\u001b[0m\n"
      ]
     }
@@ -406,19 +406,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "529cb13a",
+   "id": "ea79a4cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:23:34.272841Z",
-     "iopub.status.busy": "2026-05-20T16:23:34.272564Z",
-     "iopub.status.idle": "2026-05-20T16:23:34.278226Z",
-     "shell.execute_reply": "2026-05-20T16:23:34.277239Z"
+     "iopub.execute_input": "2026-05-20T18:19:02.738261Z",
+     "iopub.status.busy": "2026-05-20T18:19:02.737866Z",
+     "iopub.status.idle": "2026-05-20T18:19:02.743500Z",
+     "shell.execute_reply": "2026-05-20T18:19:02.742531Z"
     },
     "papermill": {
-     "duration": 0.014937,
-     "end_time": "2026-05-20T16:23:34.279318+00:00",
+     "duration": 0.015814,
+     "end_time": "2026-05-20T18:19:02.744546+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:23:34.264381+00:00",
+     "start_time": "2026-05-20T18:19:02.728732+00:00",
      "status": "completed"
     },
     "tags": []
@@ -443,19 +443,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "270f6cda",
+   "id": "6a3a798f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:23:34.295352Z",
-     "iopub.status.busy": "2026-05-20T16:23:34.295101Z",
-     "iopub.status.idle": "2026-05-20T16:23:34.302688Z",
-     "shell.execute_reply": "2026-05-20T16:23:34.301912Z"
+     "iopub.execute_input": "2026-05-20T18:19:02.761402Z",
+     "iopub.status.busy": "2026-05-20T18:19:02.761096Z",
+     "iopub.status.idle": "2026-05-20T18:19:02.767380Z",
+     "shell.execute_reply": "2026-05-20T18:19:02.766554Z"
     },
     "papermill": {
-     "duration": 0.016894,
-     "end_time": "2026-05-20T16:23:34.303609+00:00",
+     "duration": 0.015959,
+     "end_time": "2026-05-20T18:19:02.768300+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:23:34.286715+00:00",
+     "start_time": "2026-05-20T18:19:02.752341+00:00",
      "status": "completed"
     },
     "tags": []
@@ -479,19 +479,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "ab50fa9a",
+   "id": "f2337ac9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:23:34.320010Z",
-     "iopub.status.busy": "2026-05-20T16:23:34.319796Z",
-     "iopub.status.idle": "2026-05-20T16:23:47.845425Z",
-     "shell.execute_reply": "2026-05-20T16:23:47.843706Z"
+     "iopub.execute_input": "2026-05-20T18:19:02.784708Z",
+     "iopub.status.busy": "2026-05-20T18:19:02.784355Z",
+     "iopub.status.idle": "2026-05-20T18:19:16.604794Z",
+     "shell.execute_reply": "2026-05-20T18:19:16.603670Z"
     },
     "papermill": {
-     "duration": 13.535164,
-     "end_time": "2026-05-20T16:23:47.846165+00:00",
+     "duration": 13.83029,
+     "end_time": "2026-05-20T18:19:16.605953+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:23:34.311001+00:00",
+     "start_time": "2026-05-20T18:19:02.775663+00:00",
      "status": "completed"
     },
     "tags": []
@@ -508,19 +508,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "bfbb6826",
+   "id": "354006f9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:23:47.863131Z",
-     "iopub.status.busy": "2026-05-20T16:23:47.862815Z",
-     "iopub.status.idle": "2026-05-20T16:26:01.800809Z",
-     "shell.execute_reply": "2026-05-20T16:26:01.799574Z"
+     "iopub.execute_input": "2026-05-20T18:19:16.624895Z",
+     "iopub.status.busy": "2026-05-20T18:19:16.624485Z",
+     "iopub.status.idle": "2026-05-20T18:21:32.780119Z",
+     "shell.execute_reply": "2026-05-20T18:21:32.778891Z"
     },
     "papermill": {
-     "duration": 133.947205,
-     "end_time": "2026-05-20T16:26:01.801719+00:00",
+     "duration": 136.165147,
+     "end_time": "2026-05-20T18:21:32.781051+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:23:47.854514+00:00",
+     "start_time": "2026-05-20T18:19:16.615904+00:00",
      "status": "completed"
     },
     "tags": []
@@ -530,35 +530,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:24:01.202\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:19:30.246\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:24:38.839\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:20:08.788\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:24:55.180\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:20:25.499\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:25:13.060\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:20:43.555\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:25:34.662\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:21:05.436\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
      ]
     }
    ],
@@ -580,19 +580,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "d177bb4b",
+   "id": "30538170",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:01.819230Z",
-     "iopub.status.busy": "2026-05-20T16:26:01.818899Z",
-     "iopub.status.idle": "2026-05-20T16:26:15.253983Z",
-     "shell.execute_reply": "2026-05-20T16:26:15.252889Z"
+     "iopub.execute_input": "2026-05-20T18:21:32.800595Z",
+     "iopub.status.busy": "2026-05-20T18:21:32.800149Z",
+     "iopub.status.idle": "2026-05-20T18:21:46.557504Z",
+     "shell.execute_reply": "2026-05-20T18:21:46.556468Z"
     },
     "papermill": {
-     "duration": 13.45303,
-     "end_time": "2026-05-20T16:26:15.263150+00:00",
+     "duration": 13.776786,
+     "end_time": "2026-05-20T18:21:46.567411+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:01.810120+00:00",
+     "start_time": "2026-05-20T18:21:32.790625+00:00",
      "status": "completed"
     },
     "tags": []
@@ -751,19 +751,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "98acea46",
+   "id": "fb6b81db",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:15.279689Z",
-     "iopub.status.busy": "2026-05-20T16:26:15.279496Z",
-     "iopub.status.idle": "2026-05-20T16:26:15.311893Z",
-     "shell.execute_reply": "2026-05-20T16:26:15.310904Z"
+     "iopub.execute_input": "2026-05-20T18:21:46.585237Z",
+     "iopub.status.busy": "2026-05-20T18:21:46.584722Z",
+     "iopub.status.idle": "2026-05-20T18:21:46.617427Z",
+     "shell.execute_reply": "2026-05-20T18:21:46.616507Z"
     },
     "papermill": {
-     "duration": 0.042153,
-     "end_time": "2026-05-20T16:26:15.312972+00:00",
+     "duration": 0.042867,
+     "end_time": "2026-05-20T18:21:46.618470+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:15.270819+00:00",
+     "start_time": "2026-05-20T18:21:46.575603+00:00",
      "status": "completed"
     },
     "tags": []
@@ -776,19 +776,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "cd58b9c0",
+   "id": "e7f3db63",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:15.330743Z",
-     "iopub.status.busy": "2026-05-20T16:26:15.330488Z",
-     "iopub.status.idle": "2026-05-20T16:26:15.336281Z",
-     "shell.execute_reply": "2026-05-20T16:26:15.335172Z"
+     "iopub.execute_input": "2026-05-20T18:21:46.636507Z",
+     "iopub.status.busy": "2026-05-20T18:21:46.636276Z",
+     "iopub.status.idle": "2026-05-20T18:21:46.642303Z",
+     "shell.execute_reply": "2026-05-20T18:21:46.641351Z"
     },
     "papermill": {
-     "duration": 0.016656,
-     "end_time": "2026-05-20T16:26:15.337502+00:00",
+     "duration": 0.016096,
+     "end_time": "2026-05-20T18:21:46.643201+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:15.320846+00:00",
+     "start_time": "2026-05-20T18:21:46.627105+00:00",
      "status": "completed"
     },
     "tags": []
@@ -804,19 +804,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "ef3836ff",
+   "id": "ad6f7237",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:15.354776Z",
-     "iopub.status.busy": "2026-05-20T16:26:15.354557Z",
-     "iopub.status.idle": "2026-05-20T16:26:15.358885Z",
-     "shell.execute_reply": "2026-05-20T16:26:15.358115Z"
+     "iopub.execute_input": "2026-05-20T18:21:46.660928Z",
+     "iopub.status.busy": "2026-05-20T18:21:46.660693Z",
+     "iopub.status.idle": "2026-05-20T18:21:46.665035Z",
+     "shell.execute_reply": "2026-05-20T18:21:46.664085Z"
     },
     "papermill": {
-     "duration": 0.014167,
-     "end_time": "2026-05-20T16:26:15.359765+00:00",
+     "duration": 0.014423,
+     "end_time": "2026-05-20T18:21:46.665681+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:15.345598+00:00",
+     "start_time": "2026-05-20T18:21:46.651258+00:00",
      "status": "completed"
     },
     "tags": []
@@ -833,19 +833,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "29442412",
+   "id": "eff69320",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:15.377343Z",
-     "iopub.status.busy": "2026-05-20T16:26:15.377132Z",
-     "iopub.status.idle": "2026-05-20T16:26:15.406018Z",
-     "shell.execute_reply": "2026-05-20T16:26:15.405015Z"
+     "iopub.execute_input": "2026-05-20T18:21:46.682833Z",
+     "iopub.status.busy": "2026-05-20T18:21:46.682656Z",
+     "iopub.status.idle": "2026-05-20T18:21:46.712868Z",
+     "shell.execute_reply": "2026-05-20T18:21:46.711791Z"
     },
     "papermill": {
-     "duration": 0.039133,
-     "end_time": "2026-05-20T16:26:15.406968+00:00",
+     "duration": 0.040018,
+     "end_time": "2026-05-20T18:21:46.713882+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:15.367835+00:00",
+     "start_time": "2026-05-20T18:21:46.673864+00:00",
      "status": "completed"
     },
     "tags": []
@@ -877,19 +877,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "456e5753",
+   "id": "1ed4040b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:15.425128Z",
-     "iopub.status.busy": "2026-05-20T16:26:15.424853Z",
-     "iopub.status.idle": "2026-05-20T16:26:15.446563Z",
-     "shell.execute_reply": "2026-05-20T16:26:15.445718Z"
+     "iopub.execute_input": "2026-05-20T18:21:46.731605Z",
+     "iopub.status.busy": "2026-05-20T18:21:46.731282Z",
+     "iopub.status.idle": "2026-05-20T18:21:46.752842Z",
+     "shell.execute_reply": "2026-05-20T18:21:46.751728Z"
     },
     "papermill": {
-     "duration": 0.031639,
-     "end_time": "2026-05-20T16:26:15.447417+00:00",
+     "duration": 0.031227,
+     "end_time": "2026-05-20T18:21:46.753597+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:15.415778+00:00",
+     "start_time": "2026-05-20T18:21:46.722370+00:00",
      "status": "completed"
     },
     "tags": []
@@ -921,19 +921,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "24ecf6a6",
+   "id": "f80ef43b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:15.465023Z",
-     "iopub.status.busy": "2026-05-20T16:26:15.464726Z",
-     "iopub.status.idle": "2026-05-20T16:26:15.583763Z",
-     "shell.execute_reply": "2026-05-20T16:26:15.582707Z"
+     "iopub.execute_input": "2026-05-20T18:21:46.771473Z",
+     "iopub.status.busy": "2026-05-20T18:21:46.771221Z",
+     "iopub.status.idle": "2026-05-20T18:21:46.904223Z",
+     "shell.execute_reply": "2026-05-20T18:21:46.903161Z"
     },
     "papermill": {
-     "duration": 0.128774,
-     "end_time": "2026-05-20T16:26:15.584443+00:00",
+     "duration": 0.142728,
+     "end_time": "2026-05-20T18:21:46.904952+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:15.455669+00:00",
+     "start_time": "2026-05-20T18:21:46.762224+00:00",
      "status": "completed"
     },
     "tags": []
@@ -962,19 +962,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "4e3acdc8",
+   "id": "d13f7dfe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:15.601713Z",
-     "iopub.status.busy": "2026-05-20T16:26:15.601497Z",
-     "iopub.status.idle": "2026-05-20T16:26:15.621552Z",
-     "shell.execute_reply": "2026-05-20T16:26:15.620434Z"
+     "iopub.execute_input": "2026-05-20T18:21:46.923157Z",
+     "iopub.status.busy": "2026-05-20T18:21:46.922852Z",
+     "iopub.status.idle": "2026-05-20T18:21:46.943871Z",
+     "shell.execute_reply": "2026-05-20T18:21:46.942769Z"
     },
     "papermill": {
-     "duration": 0.029658,
-     "end_time": "2026-05-20T16:26:15.622368+00:00",
+     "duration": 0.031108,
+     "end_time": "2026-05-20T18:21:46.944563+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:15.592710+00:00",
+     "start_time": "2026-05-20T18:21:46.913455+00:00",
      "status": "completed"
     },
     "tags": []
@@ -989,19 +989,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "8c72a02d",
+   "id": "d3b1ac77",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:15.640941Z",
-     "iopub.status.busy": "2026-05-20T16:26:15.640702Z",
-     "iopub.status.idle": "2026-05-20T16:26:15.657458Z",
-     "shell.execute_reply": "2026-05-20T16:26:15.656355Z"
+     "iopub.execute_input": "2026-05-20T18:21:46.963386Z",
+     "iopub.status.busy": "2026-05-20T18:21:46.963173Z",
+     "iopub.status.idle": "2026-05-20T18:21:46.979818Z",
+     "shell.execute_reply": "2026-05-20T18:21:46.979031Z"
     },
     "papermill": {
-     "duration": 0.027034,
-     "end_time": "2026-05-20T16:26:15.658182+00:00",
+     "duration": 0.027509,
+     "end_time": "2026-05-20T18:21:46.981084+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:15.631148+00:00",
+     "start_time": "2026-05-20T18:21:46.953575+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1015,13 +1015,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fdd155e9",
+   "id": "1c65fd05",
    "metadata": {
     "papermill": {
-     "duration": 0.008807,
-     "end_time": "2026-05-20T16:26:15.677082+00:00",
+     "duration": 0.008639,
+     "end_time": "2026-05-20T18:21:46.998287+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:15.668275+00:00",
+     "start_time": "2026-05-20T18:21:46.989648+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1088,14 +1088,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 217.288969,
-   "end_time": "2026-05-20T16:26:16.203063+00:00",
+   "duration": 219.631705,
+   "end_time": "2026-05-20T18:21:47.527021+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "/mnt/share/homes/hjafari/repos/vivarium_gates_mncnh/tests/model_notebooks/interactive/interactive_simulation_gestational_age.ipynb",
    "output_path": "/mnt/share/homes/hjafari/repos/vivarium_gates_mncnh/tests/model_notebooks/interactive/executed/interactive_simulation_gestational_age.ipynb",
    "parameters": {},
-   "start_time": "2026-05-20T16:22:38.914094+00:00",
+   "start_time": "2026-05-20T18:18:07.895316+00:00",
    "version": "2.7.0"
   }
  },

--- a/tests/model_notebooks/interactive/executed/interactive_simulation_hemoglobin.ipynb
+++ b/tests/model_notebooks/interactive/executed/interactive_simulation_hemoglobin.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "38440a2f",
+   "id": "f3901b84",
    "metadata": {
     "papermill": {
-     "duration": 0.020498,
-     "end_time": "2026-05-20T16:26:19.235781+00:00",
+     "duration": 0.019957,
+     "end_time": "2026-05-20T18:21:50.411389+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:19.215283+00:00",
+     "start_time": "2026-05-20T18:21:50.391432+00:00",
      "status": "completed"
     },
     "tags": []
@@ -23,13 +23,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3cd5f42a",
+   "id": "64dc272e",
    "metadata": {
     "papermill": {
-     "duration": 0.01162,
-     "end_time": "2026-05-20T16:26:19.259475+00:00",
+     "duration": 0.011908,
+     "end_time": "2026-05-20T18:21:50.435308+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:19.247855+00:00",
+     "start_time": "2026-05-20T18:21:50.423400+00:00",
      "status": "completed"
     },
     "tags": []
@@ -41,19 +41,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "97842676",
+   "id": "df9aba6b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:19.283650Z",
-     "iopub.status.busy": "2026-05-20T16:26:19.283467Z",
-     "iopub.status.idle": "2026-05-20T16:26:21.888966Z",
-     "shell.execute_reply": "2026-05-20T16:26:21.887510Z"
+     "iopub.execute_input": "2026-05-20T18:21:50.460068Z",
+     "iopub.status.busy": "2026-05-20T18:21:50.459835Z",
+     "iopub.status.idle": "2026-05-20T18:21:52.888449Z",
+     "shell.execute_reply": "2026-05-20T18:21:52.887500Z"
     },
     "papermill": {
-     "duration": 2.618727,
-     "end_time": "2026-05-20T16:26:21.889751+00:00",
+     "duration": 2.442896,
+     "end_time": "2026-05-20T18:21:52.889802+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:19.271024+00:00",
+     "start_time": "2026-05-20T18:21:50.446906+00:00",
      "status": "completed"
     },
     "tags": []
@@ -67,19 +67,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "2ba8b356",
+   "id": "1aa47a9f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:21.914773Z",
-     "iopub.status.busy": "2026-05-20T16:26:21.914421Z",
-     "iopub.status.idle": "2026-05-20T16:26:23.265771Z",
-     "shell.execute_reply": "2026-05-20T16:26:23.262501Z"
+     "iopub.execute_input": "2026-05-20T18:21:52.915100Z",
+     "iopub.status.busy": "2026-05-20T18:21:52.914726Z",
+     "iopub.status.idle": "2026-05-20T18:21:54.303657Z",
+     "shell.execute_reply": "2026-05-20T18:21:54.300210Z"
     },
     "papermill": {
-     "duration": 1.365529,
-     "end_time": "2026-05-20T16:26:23.267481+00:00",
+     "duration": 1.403212,
+     "end_time": "2026-05-20T18:21:54.305421+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:21.901952+00:00",
+     "start_time": "2026-05-20T18:21:52.902209+00:00",
      "status": "completed"
     },
     "tags": []
@@ -112,19 +112,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "5405e322",
+   "id": "f57d9047",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:23.296043Z",
-     "iopub.status.busy": "2026-05-20T16:26:23.295790Z",
-     "iopub.status.idle": "2026-05-20T16:26:24.226295Z",
-     "shell.execute_reply": "2026-05-20T16:26:24.224098Z"
+     "iopub.execute_input": "2026-05-20T18:21:54.336322Z",
+     "iopub.status.busy": "2026-05-20T18:21:54.336053Z",
+     "iopub.status.idle": "2026-05-20T18:21:55.305761Z",
+     "shell.execute_reply": "2026-05-20T18:21:55.302782Z"
     },
     "papermill": {
-     "duration": 0.945277,
-     "end_time": "2026-05-20T16:26:24.228441+00:00",
+     "duration": 0.984456,
+     "end_time": "2026-05-20T18:21:55.307462+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:23.283164+00:00",
+     "start_time": "2026-05-20T18:21:54.323006+00:00",
      "status": "completed"
     },
     "tags": []
@@ -140,7 +140,7 @@
       "vivarium_build_utils==3.2.2\r\n",
       "vivarium_cluster_tools==3.1.4\r\n",
       "vivarium_dependencies==1.0.7\r\n",
-      "-e git+ssh://git@github.com/ihmeuw/vivarium_gates_mncnh.git@0096ee26c33ca456df2b51be38ce84948cb6ee28#egg=vivarium_gates_mncnh\r\n",
+      "-e git+ssh://git@github.com/ihmeuw/vivarium_gates_mncnh.git@963245346ffafd6c4eed18ce4bd97d1394635683#egg=vivarium_gates_mncnh\r\n",
       "vivarium_gbd_access==5.0.10\r\n",
       "vivarium_inputs==7.2.4\r\n",
       "vivarium_public_health==5.0.2\r\n",
@@ -155,19 +155,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "a0d729bf",
+   "id": "0fbe9b60",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:24.259754Z",
-     "iopub.status.busy": "2026-05-20T16:26:24.259429Z",
-     "iopub.status.idle": "2026-05-20T16:26:24.263740Z",
-     "shell.execute_reply": "2026-05-20T16:26:24.262912Z"
+     "iopub.execute_input": "2026-05-20T18:21:55.337840Z",
+     "iopub.status.busy": "2026-05-20T18:21:55.337586Z",
+     "iopub.status.idle": "2026-05-20T18:21:55.341859Z",
+     "shell.execute_reply": "2026-05-20T18:21:55.340956Z"
     },
     "papermill": {
-     "duration": 0.0183,
-     "end_time": "2026-05-20T16:26:24.264655+00:00",
+     "duration": 0.018679,
+     "end_time": "2026-05-20T18:21:55.342923+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:24.246355+00:00",
+     "start_time": "2026-05-20T18:21:55.324244+00:00",
      "status": "completed"
     },
     "tags": []
@@ -183,19 +183,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "9d3362de",
+   "id": "694e8b32",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:24.289588Z",
-     "iopub.status.busy": "2026-05-20T16:26:24.289289Z",
-     "iopub.status.idle": "2026-05-20T16:26:24.337641Z",
-     "shell.execute_reply": "2026-05-20T16:26:24.336566Z"
+     "iopub.execute_input": "2026-05-20T18:21:55.368433Z",
+     "iopub.status.busy": "2026-05-20T18:21:55.368144Z",
+     "iopub.status.idle": "2026-05-20T18:21:55.422139Z",
+     "shell.execute_reply": "2026-05-20T18:21:55.421327Z"
     },
     "papermill": {
-     "duration": 0.061921,
-     "end_time": "2026-05-20T16:26:24.338324+00:00",
+     "duration": 0.067734,
+     "end_time": "2026-05-20T18:21:55.422943+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:24.276403+00:00",
+     "start_time": "2026-05-20T18:21:55.355209+00:00",
      "status": "completed"
     },
     "tags": []
@@ -305,19 +305,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "fe5de127",
+   "id": "e41affc9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:24.363151Z",
-     "iopub.status.busy": "2026-05-20T16:26:24.362919Z",
-     "iopub.status.idle": "2026-05-20T16:26:26.867014Z",
-     "shell.execute_reply": "2026-05-20T16:26:26.866188Z"
+     "iopub.execute_input": "2026-05-20T18:21:55.449758Z",
+     "iopub.status.busy": "2026-05-20T18:21:55.449536Z",
+     "iopub.status.idle": "2026-05-20T18:21:58.336220Z",
+     "shell.execute_reply": "2026-05-20T18:21:58.335396Z"
     },
     "papermill": {
-     "duration": 2.5177,
-     "end_time": "2026-05-20T16:26:26.867873+00:00",
+     "duration": 2.90109,
+     "end_time": "2026-05-20T18:21:58.337146+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:24.350173+00:00",
+     "start_time": "2026-05-20T18:21:55.436056+00:00",
      "status": "completed"
     },
     "tags": []
@@ -344,19 +344,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "3e3ee91f",
+   "id": "2edc4c5a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:26.894245Z",
-     "iopub.status.busy": "2026-05-20T16:26:26.894005Z",
-     "iopub.status.idle": "2026-05-20T16:26:26.899771Z",
-     "shell.execute_reply": "2026-05-20T16:26:26.898820Z"
+     "iopub.execute_input": "2026-05-20T18:21:58.363349Z",
+     "iopub.status.busy": "2026-05-20T18:21:58.363118Z",
+     "iopub.status.idle": "2026-05-20T18:21:58.368114Z",
+     "shell.execute_reply": "2026-05-20T18:21:58.367087Z"
     },
     "papermill": {
-     "duration": 0.01969,
-     "end_time": "2026-05-20T16:26:26.900521+00:00",
+     "duration": 0.018913,
+     "end_time": "2026-05-20T18:21:58.368899+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:26.880831+00:00",
+     "start_time": "2026-05-20T18:21:58.349986+00:00",
      "status": "completed"
     },
     "tags": []
@@ -381,13 +381,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "812f7745",
+   "id": "bc4e399a",
    "metadata": {
     "papermill": {
-     "duration": 0.011624,
-     "end_time": "2026-05-20T16:26:26.924366+00:00",
+     "duration": 0.012696,
+     "end_time": "2026-05-20T18:21:58.394122+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:26.912742+00:00",
+     "start_time": "2026-05-20T18:21:58.381426+00:00",
      "status": "completed"
     },
     "tags": []
@@ -403,19 +403,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "ad813516",
+   "id": "8ee9cf28",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:26.949727Z",
-     "iopub.status.busy": "2026-05-20T16:26:26.949505Z",
-     "iopub.status.idle": "2026-05-20T16:26:27.051652Z",
-     "shell.execute_reply": "2026-05-20T16:26:27.050872Z"
+     "iopub.execute_input": "2026-05-20T18:21:58.419370Z",
+     "iopub.status.busy": "2026-05-20T18:21:58.419150Z",
+     "iopub.status.idle": "2026-05-20T18:21:58.527017Z",
+     "shell.execute_reply": "2026-05-20T18:21:58.525993Z"
     },
     "papermill": {
-     "duration": 0.115835,
-     "end_time": "2026-05-20T16:26:27.052549+00:00",
+     "duration": 0.121538,
+     "end_time": "2026-05-20T18:21:58.527743+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:26.936714+00:00",
+     "start_time": "2026-05-20T18:21:58.406205+00:00",
      "status": "completed"
     },
     "tags": []
@@ -445,13 +445,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3caa1419",
+   "id": "f2c1c3a8",
    "metadata": {
     "papermill": {
-     "duration": 0.012085,
-     "end_time": "2026-05-20T16:26:27.077032+00:00",
+     "duration": 0.013419,
+     "end_time": "2026-05-20T18:21:58.554163+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:27.064947+00:00",
+     "start_time": "2026-05-20T18:21:58.540744+00:00",
      "status": "completed"
     },
     "tags": []
@@ -467,19 +467,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "aeec0ee9",
+   "id": "fc7fe93e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:27.102573Z",
-     "iopub.status.busy": "2026-05-20T16:26:27.102245Z",
-     "iopub.status.idle": "2026-05-20T16:26:27.158044Z",
-     "shell.execute_reply": "2026-05-20T16:26:27.157200Z"
+     "iopub.execute_input": "2026-05-20T18:21:58.580100Z",
+     "iopub.status.busy": "2026-05-20T18:21:58.579876Z",
+     "iopub.status.idle": "2026-05-20T18:21:58.636867Z",
+     "shell.execute_reply": "2026-05-20T18:21:58.635813Z"
     },
     "papermill": {
-     "duration": 0.069521,
-     "end_time": "2026-05-20T16:26:27.158762+00:00",
+     "duration": 0.07126,
+     "end_time": "2026-05-20T18:21:58.637545+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:27.089241+00:00",
+     "start_time": "2026-05-20T18:21:58.566285+00:00",
      "status": "completed"
     },
     "tags": []
@@ -507,19 +507,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "df078f99",
+   "id": "c8e665ba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:27.184635Z",
-     "iopub.status.busy": "2026-05-20T16:26:27.184413Z",
-     "iopub.status.idle": "2026-05-20T16:26:27.220430Z",
-     "shell.execute_reply": "2026-05-20T16:26:27.219558Z"
+     "iopub.execute_input": "2026-05-20T18:21:58.662709Z",
+     "iopub.status.busy": "2026-05-20T18:21:58.662454Z",
+     "iopub.status.idle": "2026-05-20T18:21:58.701928Z",
+     "shell.execute_reply": "2026-05-20T18:21:58.700773Z"
     },
     "papermill": {
-     "duration": 0.04988,
-     "end_time": "2026-05-20T16:26:27.221128+00:00",
+     "duration": 0.052864,
+     "end_time": "2026-05-20T18:21:58.702660+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:27.171248+00:00",
+     "start_time": "2026-05-20T18:21:58.649796+00:00",
      "status": "completed"
     },
     "tags": []
@@ -544,13 +544,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58cac0cb",
+   "id": "bf86b5e5",
    "metadata": {
     "papermill": {
-     "duration": 0.012874,
-     "end_time": "2026-05-20T16:26:27.247722+00:00",
+     "duration": 0.013263,
+     "end_time": "2026-05-20T18:21:58.730773+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:27.234848+00:00",
+     "start_time": "2026-05-20T18:21:58.717510+00:00",
      "status": "completed"
     },
     "tags": []
@@ -566,19 +566,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "9783468a",
+   "id": "09dc9728",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:27.273665Z",
-     "iopub.status.busy": "2026-05-20T16:26:27.273452Z",
-     "iopub.status.idle": "2026-05-20T16:26:27.311189Z",
-     "shell.execute_reply": "2026-05-20T16:26:27.310420Z"
+     "iopub.execute_input": "2026-05-20T18:21:58.757184Z",
+     "iopub.status.busy": "2026-05-20T18:21:58.756877Z",
+     "iopub.status.idle": "2026-05-20T18:21:58.797431Z",
+     "shell.execute_reply": "2026-05-20T18:21:58.796368Z"
     },
     "papermill": {
-     "duration": 0.051896,
-     "end_time": "2026-05-20T16:26:27.312071+00:00",
+     "duration": 0.054816,
+     "end_time": "2026-05-20T18:21:58.798186+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:27.260175+00:00",
+     "start_time": "2026-05-20T18:21:58.743370+00:00",
      "status": "completed"
     },
     "tags": []
@@ -605,19 +605,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "ed76a4ca",
+   "id": "7296cab1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:27.338565Z",
-     "iopub.status.busy": "2026-05-20T16:26:27.338353Z",
-     "iopub.status.idle": "2026-05-20T16:26:27.440369Z",
-     "shell.execute_reply": "2026-05-20T16:26:27.439522Z"
+     "iopub.execute_input": "2026-05-20T18:21:58.825668Z",
+     "iopub.status.busy": "2026-05-20T18:21:58.825453Z",
+     "iopub.status.idle": "2026-05-20T18:21:58.932123Z",
+     "shell.execute_reply": "2026-05-20T18:21:58.930868Z"
     },
     "papermill": {
-     "duration": 0.116385,
-     "end_time": "2026-05-20T16:26:27.441320+00:00",
+     "duration": 0.121413,
+     "end_time": "2026-05-20T18:21:58.932810+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:27.324935+00:00",
+     "start_time": "2026-05-20T18:21:58.811397+00:00",
      "status": "completed"
     },
     "tags": []
@@ -647,19 +647,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "efb7103f",
+   "id": "0e10f522",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:27.469053Z",
-     "iopub.status.busy": "2026-05-20T16:26:27.468722Z",
-     "iopub.status.idle": "2026-05-20T16:26:27.582214Z",
-     "shell.execute_reply": "2026-05-20T16:26:27.581347Z"
+     "iopub.execute_input": "2026-05-20T18:21:58.959316Z",
+     "iopub.status.busy": "2026-05-20T18:21:58.959101Z",
+     "iopub.status.idle": "2026-05-20T18:21:59.074536Z",
+     "shell.execute_reply": "2026-05-20T18:21:59.073386Z"
     },
     "papermill": {
-     "duration": 0.128311,
-     "end_time": "2026-05-20T16:26:27.583043+00:00",
+     "duration": 0.129438,
+     "end_time": "2026-05-20T18:21:59.075212+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:27.454732+00:00",
+     "start_time": "2026-05-20T18:21:58.945774+00:00",
      "status": "completed"
     },
     "tags": []
@@ -687,19 +687,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "23710260",
+   "id": "6c30005a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:27.610088Z",
-     "iopub.status.busy": "2026-05-20T16:26:27.609864Z",
-     "iopub.status.idle": "2026-05-20T16:26:27.830621Z",
-     "shell.execute_reply": "2026-05-20T16:26:27.829538Z"
+     "iopub.execute_input": "2026-05-20T18:21:59.103391Z",
+     "iopub.status.busy": "2026-05-20T18:21:59.103062Z",
+     "iopub.status.idle": "2026-05-20T18:21:59.335005Z",
+     "shell.execute_reply": "2026-05-20T18:21:59.333595Z"
     },
     "papermill": {
-     "duration": 0.234817,
-     "end_time": "2026-05-20T16:26:27.831299+00:00",
+     "duration": 0.247221,
+     "end_time": "2026-05-20T18:21:59.335707+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:27.596482+00:00",
+     "start_time": "2026-05-20T18:21:59.088486+00:00",
      "status": "completed"
     },
     "tags": []
@@ -737,19 +737,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "b0cd6c2c",
+   "id": "6f2c9994",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:27.857708Z",
-     "iopub.status.busy": "2026-05-20T16:26:27.857489Z",
-     "iopub.status.idle": "2026-05-20T16:26:28.085752Z",
-     "shell.execute_reply": "2026-05-20T16:26:28.084689Z"
+     "iopub.execute_input": "2026-05-20T18:21:59.363571Z",
+     "iopub.status.busy": "2026-05-20T18:21:59.363349Z",
+     "iopub.status.idle": "2026-05-20T18:21:59.599989Z",
+     "shell.execute_reply": "2026-05-20T18:21:59.599018Z"
     },
     "papermill": {
-     "duration": 0.242305,
-     "end_time": "2026-05-20T16:26:28.086433+00:00",
+     "duration": 0.251558,
+     "end_time": "2026-05-20T18:21:59.600964+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:27.844128+00:00",
+     "start_time": "2026-05-20T18:21:59.349406+00:00",
      "status": "completed"
     },
     "tags": []
@@ -783,19 +783,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "2c7204dd",
+   "id": "545032ab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:28.113717Z",
-     "iopub.status.busy": "2026-05-20T16:26:28.113424Z",
-     "iopub.status.idle": "2026-05-20T16:26:28.151369Z",
-     "shell.execute_reply": "2026-05-20T16:26:28.150318Z"
+     "iopub.execute_input": "2026-05-20T18:21:59.628739Z",
+     "iopub.status.busy": "2026-05-20T18:21:59.628419Z",
+     "iopub.status.idle": "2026-05-20T18:21:59.665940Z",
+     "shell.execute_reply": "2026-05-20T18:21:59.665143Z"
     },
     "papermill": {
-     "duration": 0.052402,
-     "end_time": "2026-05-20T16:26:28.152019+00:00",
+     "duration": 0.052204,
+     "end_time": "2026-05-20T18:21:59.666806+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:28.099617+00:00",
+     "start_time": "2026-05-20T18:21:59.614602+00:00",
      "status": "completed"
     },
     "tags": []
@@ -821,13 +821,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9487231e",
+   "id": "35adaf84",
    "metadata": {
     "papermill": {
-     "duration": 0.013039,
-     "end_time": "2026-05-20T16:26:28.177919+00:00",
+     "duration": 0.015719,
+     "end_time": "2026-05-20T18:21:59.695225+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:28.164880+00:00",
+     "start_time": "2026-05-20T18:21:59.679506+00:00",
      "status": "completed"
     },
     "tags": []
@@ -843,19 +843,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "990e6663",
+   "id": "11538fe8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:28.204792Z",
-     "iopub.status.busy": "2026-05-20T16:26:28.204555Z",
-     "iopub.status.idle": "2026-05-20T16:26:29.880690Z",
-     "shell.execute_reply": "2026-05-20T16:26:29.879510Z"
+     "iopub.execute_input": "2026-05-20T18:21:59.722648Z",
+     "iopub.status.busy": "2026-05-20T18:21:59.722426Z",
+     "iopub.status.idle": "2026-05-20T18:22:01.531422Z",
+     "shell.execute_reply": "2026-05-20T18:22:01.530322Z"
     },
     "papermill": {
-     "duration": 1.690946,
-     "end_time": "2026-05-20T16:26:29.881666+00:00",
+     "duration": 1.823957,
+     "end_time": "2026-05-20T18:22:01.532324+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:28.190720+00:00",
+     "start_time": "2026-05-20T18:21:59.708367+00:00",
      "status": "completed"
     },
     "tags": []
@@ -899,19 +899,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "bd17679d",
+   "id": "3e422197",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:29.910065Z",
-     "iopub.status.busy": "2026-05-20T16:26:29.909831Z",
-     "iopub.status.idle": "2026-05-20T16:26:29.915525Z",
-     "shell.execute_reply": "2026-05-20T16:26:29.914636Z"
+     "iopub.execute_input": "2026-05-20T18:22:01.561943Z",
+     "iopub.status.busy": "2026-05-20T18:22:01.561475Z",
+     "iopub.status.idle": "2026-05-20T18:22:01.567167Z",
+     "shell.execute_reply": "2026-05-20T18:22:01.566227Z"
     },
     "papermill": {
-     "duration": 0.020908,
-     "end_time": "2026-05-20T16:26:29.916460+00:00",
+     "duration": 0.020543,
+     "end_time": "2026-05-20T18:22:01.567820+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:29.895552+00:00",
+     "start_time": "2026-05-20T18:22:01.547277+00:00",
      "status": "completed"
     },
     "tags": []
@@ -937,13 +937,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30d34ee1",
+   "id": "621cc21c",
    "metadata": {
     "papermill": {
-     "duration": 0.013781,
-     "end_time": "2026-05-20T16:26:29.943530+00:00",
+     "duration": 0.013171,
+     "end_time": "2026-05-20T18:22:01.594629+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:29.929749+00:00",
+     "start_time": "2026-05-20T18:22:01.581458+00:00",
      "status": "completed"
     },
     "tags": []
@@ -959,19 +959,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "4c0e2122",
+   "id": "9a9de83e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:29.971088Z",
-     "iopub.status.busy": "2026-05-20T16:26:29.970904Z",
-     "iopub.status.idle": "2026-05-20T16:26:30.051556Z",
-     "shell.execute_reply": "2026-05-20T16:26:30.050756Z"
+     "iopub.execute_input": "2026-05-20T18:22:01.622717Z",
+     "iopub.status.busy": "2026-05-20T18:22:01.622499Z",
+     "iopub.status.idle": "2026-05-20T18:22:01.703449Z",
+     "shell.execute_reply": "2026-05-20T18:22:01.702663Z"
     },
     "papermill": {
-     "duration": 0.095775,
-     "end_time": "2026-05-20T16:26:30.052453+00:00",
+     "duration": 0.096412,
+     "end_time": "2026-05-20T18:22:01.704336+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:29.956678+00:00",
+     "start_time": "2026-05-20T18:22:01.607924+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1040,19 +1040,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "d5f1487f",
+   "id": "448326d9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:30.080920Z",
-     "iopub.status.busy": "2026-05-20T16:26:30.080602Z",
-     "iopub.status.idle": "2026-05-20T16:26:30.254698Z",
-     "shell.execute_reply": "2026-05-20T16:26:30.253926Z"
+     "iopub.execute_input": "2026-05-20T18:22:01.734130Z",
+     "iopub.status.busy": "2026-05-20T18:22:01.733845Z",
+     "iopub.status.idle": "2026-05-20T18:22:01.913557Z",
+     "shell.execute_reply": "2026-05-20T18:22:01.912718Z"
     },
     "papermill": {
-     "duration": 0.189356,
-     "end_time": "2026-05-20T16:26:30.255667+00:00",
+     "duration": 0.195363,
+     "end_time": "2026-05-20T18:22:01.914605+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:30.066311+00:00",
+     "start_time": "2026-05-20T18:22:01.719242+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1065,13 +1065,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "724e52c3",
+   "id": "388bc718",
    "metadata": {
     "papermill": {
-     "duration": 0.013375,
-     "end_time": "2026-05-20T16:26:30.282626+00:00",
+     "duration": 0.013408,
+     "end_time": "2026-05-20T18:22:01.942142+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:30.269251+00:00",
+     "start_time": "2026-05-20T18:22:01.928734+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1085,19 +1085,19 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "ce6d609f",
+   "id": "c2df2ce7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:26:30.311548Z",
-     "iopub.status.busy": "2026-05-20T16:26:30.311322Z",
-     "iopub.status.idle": "2026-05-20T16:29:16.867099Z",
-     "shell.execute_reply": "2026-05-20T16:29:16.866066Z"
+     "iopub.execute_input": "2026-05-20T18:22:01.970544Z",
+     "iopub.status.busy": "2026-05-20T18:22:01.970318Z",
+     "iopub.status.idle": "2026-05-20T18:24:50.412842Z",
+     "shell.execute_reply": "2026-05-20T18:24:50.411768Z"
     },
     "papermill": {
-     "duration": 166.571699,
-     "end_time": "2026-05-20T16:29:16.868118+00:00",
+     "duration": 168.45791,
+     "end_time": "2026-05-20T18:24:50.413832+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:26:30.296419+00:00",
+     "start_time": "2026-05-20T18:22:01.955922+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1107,147 +1107,147 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:26:31.320\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:22:02.949\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:26:31.321\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:22:02.950\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:26:31.322\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:22:02.952\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:09.919\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:22:42.542\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:09.920\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:22:42.543\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:10.120\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:22:42.725\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:10.121\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:22:42.725\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:10.122\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:22:42.726\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:10.122\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:22:42.727\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:10.123\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:22:42.728\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:10.123\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:22:42.728\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:10.124\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:22:42.729\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:10.124\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:22:42.729\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:10.125\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:22:42.730\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:10.126\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:22:42.730\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:10.126\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:22:42.731\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:10.127\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:22:42.731\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:10.127\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:22:42.732\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:10.128\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:22:42.732\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:10.128\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:22:42.733\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:10.129\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
+      "\u001b[32m2026-05-20 11:22:42.734\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
       "['ferritin_screening_coverage', 'hemoglobin_screening_coverage', 'sex']\u001b[0m\n"
      ]
     },
@@ -1255,147 +1255,147 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:12.664\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:22:45.351\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:12.666\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:22:45.352\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:12.666\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:22:45.353\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:51.412\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:23:25.464\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:51.413\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:23:25.465\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:51.600\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:23:25.647\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:51.600\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:23:25.648\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:51.601\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:23:25.648\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:51.601\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:23:25.649\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:51.602\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:23:25.649\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:51.602\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:23:25.650\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:51.603\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:23:25.650\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:51.603\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:23:25.651\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:51.604\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:23:25.652\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:51.604\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:23:25.652\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:51.605\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:23:25.653\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:51.606\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:23:25.653\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:51.606\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:23:25.654\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:51.607\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:23:25.654\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:51.607\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:23:25.655\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:51.608\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
+      "\u001b[32m2026-05-20 11:23:25.655\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
       "['ferritin_screening_coverage', 'hemoglobin_screening_coverage', 'sex']\u001b[0m\n"
      ]
     },
@@ -1403,147 +1403,147 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:54.074\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:23:28.041\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:54.075\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:23:28.042\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:27:54.075\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:23:28.042\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:28:32.775\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:06.766\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:28:32.776\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:06.767\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:28:32.960\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:06.955\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:28:32.961\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:06.956\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:28:32.961\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:06.956\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:28:32.962\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:06.957\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:28:32.962\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:06.958\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:28:32.963\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:06.958\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:28:32.963\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:06.959\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:28:32.966\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:06.959\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:28:32.966\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:06.960\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:28:32.967\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:06.960\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:28:32.967\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:06.961\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:28:32.968\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:06.961\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:28:32.969\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:06.963\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:28:32.969\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:06.964\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:28:32.970\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:06.964\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:28:32.973\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
+      "\u001b[32m2026-05-20 11:24:06.965\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
       "['ferritin_screening_coverage', 'hemoglobin_screening_coverage', 'sex']\u001b[0m\n"
      ]
     },
@@ -1551,147 +1551,147 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:28:35.490\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:09.401\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:28:35.490\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:09.402\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:28:35.491\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:09.402\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:29:14.298\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:47.826\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:29:14.298\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:47.827\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:29:14.481\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:48.009\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:29:14.481\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:48.010\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:29:14.482\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:48.010\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:29:14.482\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:48.011\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:29:14.483\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:48.011\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:29:14.483\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:48.012\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:29:14.484\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:48.012\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:29:14.484\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:48.013\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:29:14.485\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:48.013\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:29:14.485\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:48.014\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:29:14.486\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:48.014\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:29:14.487\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:48.015\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:29:14.487\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:48.016\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:29:14.488\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:48.016\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:29:14.488\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:48.017\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:29:14.489\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
+      "\u001b[32m2026-05-20 11:24:48.017\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
       "['ferritin_screening_coverage', 'hemoglobin_screening_coverage', 'sex']\u001b[0m\n"
      ]
     },
@@ -1748,13 +1748,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c7537a0b",
+   "id": "c8ee3223",
    "metadata": {
     "papermill": {
-     "duration": 0.018621,
-     "end_time": "2026-05-20T16:29:16.906844+00:00",
+     "duration": 0.017033,
+     "end_time": "2026-05-20T18:24:50.451239+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:29:16.888223+00:00",
+     "start_time": "2026-05-20T18:24:50.434206+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1772,19 +1772,19 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "b06742d9",
+   "id": "895665cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:29:16.942032Z",
-     "iopub.status.busy": "2026-05-20T16:29:16.941706Z",
-     "iopub.status.idle": "2026-05-20T16:29:21.831763Z",
-     "shell.execute_reply": "2026-05-20T16:29:21.830728Z"
+     "iopub.execute_input": "2026-05-20T18:24:50.487297Z",
+     "iopub.status.busy": "2026-05-20T18:24:50.487021Z",
+     "iopub.status.idle": "2026-05-20T18:24:55.355414Z",
+     "shell.execute_reply": "2026-05-20T18:24:55.354490Z"
     },
     "papermill": {
-     "duration": 4.908932,
-     "end_time": "2026-05-20T16:29:21.832829+00:00",
+     "duration": 4.887771,
+     "end_time": "2026-05-20T18:24:55.356287+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:29:16.923897+00:00",
+     "start_time": "2026-05-20T18:24:50.468516+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1836,13 +1836,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0011ada3",
+   "id": "596dbd19",
    "metadata": {
     "papermill": {
-     "duration": 0.016955,
-     "end_time": "2026-05-20T16:29:21.868046+00:00",
+     "duration": 0.017778,
+     "end_time": "2026-05-20T18:24:55.393045+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:29:21.851091+00:00",
+     "start_time": "2026-05-20T18:24:55.375267+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1869,19 +1869,19 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "1fadd4b5",
+   "id": "e0f65c11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:29:21.904488Z",
-     "iopub.status.busy": "2026-05-20T16:29:21.904277Z",
-     "iopub.status.idle": "2026-05-20T16:30:21.119022Z",
-     "shell.execute_reply": "2026-05-20T16:30:21.118174Z"
+     "iopub.execute_input": "2026-05-20T18:24:55.428880Z",
+     "iopub.status.busy": "2026-05-20T18:24:55.428619Z",
+     "iopub.status.idle": "2026-05-20T18:25:55.857745Z",
+     "shell.execute_reply": "2026-05-20T18:25:55.856710Z"
     },
     "papermill": {
-     "duration": 59.234268,
-     "end_time": "2026-05-20T16:30:21.119988+00:00",
+     "duration": 60.448321,
+     "end_time": "2026-05-20T18:25:55.858676+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:29:21.885720+00:00",
+     "start_time": "2026-05-20T18:24:55.410355+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1891,7 +1891,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:29:21.917\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:24:55.441\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -1936,7 +1936,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:29:36.634\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:25:10.393\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -1979,7 +1979,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:29:51.308\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:25:25.157\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -2024,7 +2024,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:30:06.162\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:25:40.631\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -2211,13 +2211,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2aa066b7",
+   "id": "1a3309a6",
    "metadata": {
     "papermill": {
-     "duration": 0.018866,
-     "end_time": "2026-05-20T16:30:21.157671+00:00",
+     "duration": 0.019519,
+     "end_time": "2026-05-20T18:25:55.897996+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:30:21.138805+00:00",
+     "start_time": "2026-05-20T18:25:55.878477+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2239,19 +2239,19 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "28acc1c4",
+   "id": "80585376",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:30:21.196573Z",
-     "iopub.status.busy": "2026-05-20T16:30:21.196372Z",
-     "iopub.status.idle": "2026-05-20T16:30:28.113015Z",
-     "shell.execute_reply": "2026-05-20T16:30:28.112139Z"
+     "iopub.execute_input": "2026-05-20T18:25:55.936773Z",
+     "iopub.status.busy": "2026-05-20T18:25:55.936548Z",
+     "iopub.status.idle": "2026-05-20T18:26:03.022144Z",
+     "shell.execute_reply": "2026-05-20T18:26:03.021187Z"
     },
     "papermill": {
-     "duration": 6.937036,
-     "end_time": "2026-05-20T16:30:28.114113+00:00",
+     "duration": 7.106634,
+     "end_time": "2026-05-20T18:26:03.023095+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:30:21.177077+00:00",
+     "start_time": "2026-05-20T18:25:55.916461+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2261,7 +2261,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:30:21.203\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:25:55.944\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -2308,7 +2308,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:30:22.905\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:25:57.664\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -2355,7 +2355,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:30:24.583\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:25:59.404\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -2690,7 +2690,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:30:26.343\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:26:01.229\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -3092,13 +3092,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aaeac6f3",
+   "id": "8736a31a",
    "metadata": {
     "papermill": {
-     "duration": 0.020611,
-     "end_time": "2026-05-20T16:30:28.156333+00:00",
+     "duration": 0.019993,
+     "end_time": "2026-05-20T18:26:03.064608+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:30:28.135722+00:00",
+     "start_time": "2026-05-20T18:26:03.044615+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3120,19 +3120,19 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "e5b47ef3",
+   "id": "4af99128",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:30:28.199331Z",
-     "iopub.status.busy": "2026-05-20T16:30:28.199072Z",
-     "iopub.status.idle": "2026-05-20T16:30:39.112632Z",
-     "shell.execute_reply": "2026-05-20T16:30:39.111593Z"
+     "iopub.execute_input": "2026-05-20T18:26:03.106941Z",
+     "iopub.status.busy": "2026-05-20T18:26:03.106569Z",
+     "iopub.status.idle": "2026-05-20T18:26:14.540978Z",
+     "shell.execute_reply": "2026-05-20T18:26:14.540047Z"
     },
     "papermill": {
-     "duration": 10.936573,
-     "end_time": "2026-05-20T16:30:39.113845+00:00",
+     "duration": 11.457686,
+     "end_time": "2026-05-20T18:26:14.542274+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:30:28.177272+00:00",
+     "start_time": "2026-05-20T18:26:03.084588+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3142,7 +3142,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:30:28.832\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:26:03.767\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -3262,7 +3262,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:30:31.592\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:26:06.721\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -3382,7 +3382,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:30:34.245\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:26:09.442\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -3502,7 +3502,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:30:36.970\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:26:12.227\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -3708,13 +3708,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "90225df2",
+   "id": "29fc096e",
    "metadata": {
     "papermill": {
-     "duration": 0.021183,
-     "end_time": "2026-05-20T16:30:39.157831+00:00",
+     "duration": 0.021277,
+     "end_time": "2026-05-20T18:26:14.586755+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:30:39.136648+00:00",
+     "start_time": "2026-05-20T18:26:14.565478+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3731,19 +3731,19 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "10ebdf72",
+   "id": "563fc885",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:30:39.204500Z",
-     "iopub.status.busy": "2026-05-20T16:30:39.204116Z",
-     "iopub.status.idle": "2026-05-20T16:31:42.332201Z",
-     "shell.execute_reply": "2026-05-20T16:31:42.330925Z"
+     "iopub.execute_input": "2026-05-20T18:26:14.642956Z",
+     "iopub.status.busy": "2026-05-20T18:26:14.642611Z",
+     "iopub.status.idle": "2026-05-20T18:27:19.194266Z",
+     "shell.execute_reply": "2026-05-20T18:27:19.193113Z"
     },
     "papermill": {
-     "duration": 63.154283,
-     "end_time": "2026-05-20T16:31:42.333043+00:00",
+     "duration": 64.584795,
+     "end_time": "2026-05-20T18:27:19.195414+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:30:39.178760+00:00",
+     "start_time": "2026-05-20T18:26:14.610619+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3753,28 +3753,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:30:39.210\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:26:14.649\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:30:55.043\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:26:30.912\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:31:10.678\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:26:47.002\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:31:26.519\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:27:03.085\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
      ]
     }
    ],
@@ -3814,13 +3814,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46648f22",
+   "id": "0d044778",
    "metadata": {
     "papermill": {
-     "duration": 0.022596,
-     "end_time": "2026-05-20T16:31:42.380731+00:00",
+     "duration": 0.022088,
+     "end_time": "2026-05-20T18:27:19.242359+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:31:42.358135+00:00",
+     "start_time": "2026-05-20T18:27:19.220271+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3840,19 +3840,19 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "a7d863c7",
+   "id": "b6dc68d8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:31:42.425881Z",
-     "iopub.status.busy": "2026-05-20T16:31:42.425636Z",
-     "iopub.status.idle": "2026-05-20T16:33:19.226909Z",
-     "shell.execute_reply": "2026-05-20T16:33:19.225881Z"
+     "iopub.execute_input": "2026-05-20T18:27:19.288430Z",
+     "iopub.status.busy": "2026-05-20T18:27:19.288171Z",
+     "iopub.status.idle": "2026-05-20T18:28:51.571039Z",
+     "shell.execute_reply": "2026-05-20T18:28:51.569981Z"
     },
     "papermill": {
-     "duration": 96.825989,
-     "end_time": "2026-05-20T16:33:19.227861+00:00",
+     "duration": 92.307929,
+     "end_time": "2026-05-20T18:28:51.572193+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:31:42.401872+00:00",
+     "start_time": "2026-05-20T18:27:19.264264+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3862,28 +3862,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:31:42.432\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:27:19.295\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:32:05.762\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:27:42.209\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:32:28.872\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:28:04.397\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:32:52.612\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:28:27.560\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
      ]
     }
    ],
@@ -3946,19 +3946,19 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "358f6e8e",
+   "id": "43ca13bd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:33:19.273497Z",
-     "iopub.status.busy": "2026-05-20T16:33:19.273262Z",
-     "iopub.status.idle": "2026-05-20T16:33:19.323359Z",
-     "shell.execute_reply": "2026-05-20T16:33:19.322202Z"
+     "iopub.execute_input": "2026-05-20T18:28:51.622062Z",
+     "iopub.status.busy": "2026-05-20T18:28:51.621811Z",
+     "iopub.status.idle": "2026-05-20T18:28:51.673301Z",
+     "shell.execute_reply": "2026-05-20T18:28:51.672414Z"
     },
     "papermill": {
-     "duration": 0.074728,
-     "end_time": "2026-05-20T16:33:19.324609+00:00",
+     "duration": 0.07652,
+     "end_time": "2026-05-20T18:28:51.674411+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:19.249881+00:00",
+     "start_time": "2026-05-20T18:28:51.597891+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3995,19 +3995,19 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "aca8cf45",
+   "id": "8148c1c5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:33:19.372909Z",
-     "iopub.status.busy": "2026-05-20T16:33:19.372596Z",
-     "iopub.status.idle": "2026-05-20T16:33:21.319088Z",
-     "shell.execute_reply": "2026-05-20T16:33:21.317987Z"
+     "iopub.execute_input": "2026-05-20T18:28:51.721880Z",
+     "iopub.status.busy": "2026-05-20T18:28:51.721612Z",
+     "iopub.status.idle": "2026-05-20T18:28:53.699314Z",
+     "shell.execute_reply": "2026-05-20T18:28:53.698196Z"
     },
     "papermill": {
-     "duration": 1.971724,
-     "end_time": "2026-05-20T16:33:21.320152+00:00",
+     "duration": 2.001629,
+     "end_time": "2026-05-20T18:28:53.700431+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:19.348428+00:00",
+     "start_time": "2026-05-20T18:28:51.698802+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4034,19 +4034,19 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "8b238979",
+   "id": "e78a4ccf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:33:21.366275Z",
-     "iopub.status.busy": "2026-05-20T16:33:21.366073Z",
-     "iopub.status.idle": "2026-05-20T16:33:21.377342Z",
-     "shell.execute_reply": "2026-05-20T16:33:21.376537Z"
+     "iopub.execute_input": "2026-05-20T18:28:53.751067Z",
+     "iopub.status.busy": "2026-05-20T18:28:53.750554Z",
+     "iopub.status.idle": "2026-05-20T18:28:53.762969Z",
+     "shell.execute_reply": "2026-05-20T18:28:53.761652Z"
     },
     "papermill": {
-     "duration": 0.034339,
-     "end_time": "2026-05-20T16:33:21.378219+00:00",
+     "duration": 0.038429,
+     "end_time": "2026-05-20T18:28:53.763675+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:21.343880+00:00",
+     "start_time": "2026-05-20T18:28:53.725246+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4058,13 +4058,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e0fe5b29",
+   "id": "fd467275",
    "metadata": {
     "papermill": {
-     "duration": 0.023717,
-     "end_time": "2026-05-20T16:33:21.424439+00:00",
+     "duration": 0.023006,
+     "end_time": "2026-05-20T18:28:53.809904+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:21.400722+00:00",
+     "start_time": "2026-05-20T18:28:53.786898+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4078,19 +4078,19 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "id": "8dfb3eea",
+   "id": "04f3fc5e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:33:21.473592Z",
-     "iopub.status.busy": "2026-05-20T16:33:21.473365Z",
-     "iopub.status.idle": "2026-05-20T16:33:21.501713Z",
-     "shell.execute_reply": "2026-05-20T16:33:21.500394Z"
+     "iopub.execute_input": "2026-05-20T18:28:53.863274Z",
+     "iopub.status.busy": "2026-05-20T18:28:53.862997Z",
+     "iopub.status.idle": "2026-05-20T18:28:53.891943Z",
+     "shell.execute_reply": "2026-05-20T18:28:53.890865Z"
     },
     "papermill": {
-     "duration": 0.054052,
-     "end_time": "2026-05-20T16:33:21.502503+00:00",
+     "duration": 0.05948,
+     "end_time": "2026-05-20T18:28:53.893092+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:21.448451+00:00",
+     "start_time": "2026-05-20T18:28:53.833612+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4124,13 +4124,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12b23d96",
+   "id": "7ea3770a",
    "metadata": {
     "papermill": {
-     "duration": 0.022562,
-     "end_time": "2026-05-20T16:33:21.548502+00:00",
+     "duration": 0.021582,
+     "end_time": "2026-05-20T18:28:53.939426+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:21.525940+00:00",
+     "start_time": "2026-05-20T18:28:53.917844+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4145,19 +4145,19 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "6e256461",
+   "id": "54c639b1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:33:21.595631Z",
-     "iopub.status.busy": "2026-05-20T16:33:21.595315Z",
-     "iopub.status.idle": "2026-05-20T16:33:21.599232Z",
-     "shell.execute_reply": "2026-05-20T16:33:21.598174Z"
+     "iopub.execute_input": "2026-05-20T18:28:53.987186Z",
+     "iopub.status.busy": "2026-05-20T18:28:53.986930Z",
+     "iopub.status.idle": "2026-05-20T18:28:53.990715Z",
+     "shell.execute_reply": "2026-05-20T18:28:53.989827Z"
     },
     "papermill": {
-     "duration": 0.028605,
-     "end_time": "2026-05-20T16:33:21.599936+00:00",
+     "duration": 0.029279,
+     "end_time": "2026-05-20T18:28:53.991455+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:21.571331+00:00",
+     "start_time": "2026-05-20T18:28:53.962176+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4171,19 +4171,19 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "id": "f2f55281",
+   "id": "22d605e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:33:21.646056Z",
-     "iopub.status.busy": "2026-05-20T16:33:21.645841Z",
-     "iopub.status.idle": "2026-05-20T16:33:21.726097Z",
-     "shell.execute_reply": "2026-05-20T16:33:21.725009Z"
+     "iopub.execute_input": "2026-05-20T18:28:54.040504Z",
+     "iopub.status.busy": "2026-05-20T18:28:54.040279Z",
+     "iopub.status.idle": "2026-05-20T18:28:54.125690Z",
+     "shell.execute_reply": "2026-05-20T18:28:54.124721Z"
     },
     "papermill": {
-     "duration": 0.104937,
-     "end_time": "2026-05-20T16:33:21.727253+00:00",
+     "duration": 0.109114,
+     "end_time": "2026-05-20T18:28:54.126609+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:21.622316+00:00",
+     "start_time": "2026-05-20T18:28:54.017495+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4197,19 +4197,19 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "id": "8e231338",
+   "id": "fc3a7772",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:33:21.774110Z",
-     "iopub.status.busy": "2026-05-20T16:33:21.773871Z",
-     "iopub.status.idle": "2026-05-20T16:33:21.778844Z",
-     "shell.execute_reply": "2026-05-20T16:33:21.777898Z"
+     "iopub.execute_input": "2026-05-20T18:28:54.177360Z",
+     "iopub.status.busy": "2026-05-20T18:28:54.177102Z",
+     "iopub.status.idle": "2026-05-20T18:28:54.182014Z",
+     "shell.execute_reply": "2026-05-20T18:28:54.181067Z"
     },
     "papermill": {
-     "duration": 0.028959,
-     "end_time": "2026-05-20T16:33:21.779628+00:00",
+     "duration": 0.030658,
+     "end_time": "2026-05-20T18:28:54.182802+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:21.750669+00:00",
+     "start_time": "2026-05-20T18:28:54.152144+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4233,19 +4233,19 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "id": "25bdddeb",
+   "id": "3ead5301",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:33:21.825523Z",
-     "iopub.status.busy": "2026-05-20T16:33:21.825305Z",
-     "iopub.status.idle": "2026-05-20T16:33:21.848473Z",
-     "shell.execute_reply": "2026-05-20T16:33:21.847391Z"
+     "iopub.execute_input": "2026-05-20T18:28:54.231174Z",
+     "iopub.status.busy": "2026-05-20T18:28:54.230878Z",
+     "iopub.status.idle": "2026-05-20T18:28:54.257098Z",
+     "shell.execute_reply": "2026-05-20T18:28:54.255943Z"
     },
     "papermill": {
-     "duration": 0.048102,
-     "end_time": "2026-05-20T16:33:21.849209+00:00",
+     "duration": 0.051242,
+     "end_time": "2026-05-20T18:28:54.258047+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:21.801107+00:00",
+     "start_time": "2026-05-20T18:28:54.206805+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4273,19 +4273,19 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "id": "9b0a7040",
+   "id": "0c945f07",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:33:21.900224Z",
-     "iopub.status.busy": "2026-05-20T16:33:21.899975Z",
-     "iopub.status.idle": "2026-05-20T16:33:22.233761Z",
-     "shell.execute_reply": "2026-05-20T16:33:22.232937Z"
+     "iopub.execute_input": "2026-05-20T18:28:54.307445Z",
+     "iopub.status.busy": "2026-05-20T18:28:54.307145Z",
+     "iopub.status.idle": "2026-05-20T18:28:54.644003Z",
+     "shell.execute_reply": "2026-05-20T18:28:54.642944Z"
     },
     "papermill": {
-     "duration": 0.361709,
-     "end_time": "2026-05-20T16:33:22.234660+00:00",
+     "duration": 0.362254,
+     "end_time": "2026-05-20T18:28:54.645303+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:21.872951+00:00",
+     "start_time": "2026-05-20T18:28:54.283049+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4331,13 +4331,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f7a31528",
+   "id": "235316c7",
    "metadata": {
     "papermill": {
-     "duration": 0.022118,
-     "end_time": "2026-05-20T16:33:22.281614+00:00",
+     "duration": 0.025082,
+     "end_time": "2026-05-20T18:28:54.696479+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:22.259496+00:00",
+     "start_time": "2026-05-20T18:28:54.671397+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4353,19 +4353,19 @@
   {
    "cell_type": "code",
    "execution_count": 37,
-   "id": "6d422724",
+   "id": "3be57383",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:33:22.329888Z",
-     "iopub.status.busy": "2026-05-20T16:33:22.329618Z",
-     "iopub.status.idle": "2026-05-20T16:33:22.334732Z",
-     "shell.execute_reply": "2026-05-20T16:33:22.333737Z"
+     "iopub.execute_input": "2026-05-20T18:28:54.749002Z",
+     "iopub.status.busy": "2026-05-20T18:28:54.748416Z",
+     "iopub.status.idle": "2026-05-20T18:28:54.753713Z",
+     "shell.execute_reply": "2026-05-20T18:28:54.752708Z"
     },
     "papermill": {
-     "duration": 0.030597,
-     "end_time": "2026-05-20T16:33:22.335592+00:00",
+     "duration": 0.032063,
+     "end_time": "2026-05-20T18:28:54.754454+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:22.304995+00:00",
+     "start_time": "2026-05-20T18:28:54.722391+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4389,19 +4389,19 @@
   {
    "cell_type": "code",
    "execution_count": 38,
-   "id": "98d67baf",
+   "id": "df2d04ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:33:22.387298Z",
-     "iopub.status.busy": "2026-05-20T16:33:22.387081Z",
-     "iopub.status.idle": "2026-05-20T16:33:22.412457Z",
-     "shell.execute_reply": "2026-05-20T16:33:22.411488Z"
+     "iopub.execute_input": "2026-05-20T18:28:54.811070Z",
+     "iopub.status.busy": "2026-05-20T18:28:54.810805Z",
+     "iopub.status.idle": "2026-05-20T18:28:54.838265Z",
+     "shell.execute_reply": "2026-05-20T18:28:54.837279Z"
     },
     "papermill": {
-     "duration": 0.050633,
-     "end_time": "2026-05-20T16:33:22.413194+00:00",
+     "duration": 0.054495,
+     "end_time": "2026-05-20T18:28:54.839233+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:22.362561+00:00",
+     "start_time": "2026-05-20T18:28:54.784738+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4438,13 +4438,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a1b4ed5",
+   "id": "c9bfe47d",
    "metadata": {
     "papermill": {
-     "duration": 0.024765,
-     "end_time": "2026-05-20T16:33:22.463846+00:00",
+     "duration": 0.025887,
+     "end_time": "2026-05-20T18:28:54.890078+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:22.439081+00:00",
+     "start_time": "2026-05-20T18:28:54.864191+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4460,19 +4460,19 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "id": "264e48a7",
+   "id": "a3439a99",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:33:22.512880Z",
-     "iopub.status.busy": "2026-05-20T16:33:22.512595Z",
-     "iopub.status.idle": "2026-05-20T16:33:22.540176Z",
-     "shell.execute_reply": "2026-05-20T16:33:22.539150Z"
+     "iopub.execute_input": "2026-05-20T18:28:54.941466Z",
+     "iopub.status.busy": "2026-05-20T18:28:54.941177Z",
+     "iopub.status.idle": "2026-05-20T18:28:54.972197Z",
+     "shell.execute_reply": "2026-05-20T18:28:54.971164Z"
     },
     "papermill": {
-     "duration": 0.053175,
-     "end_time": "2026-05-20T16:33:22.540986+00:00",
+     "duration": 0.05779,
+     "end_time": "2026-05-20T18:28:54.973068+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:22.487811+00:00",
+     "start_time": "2026-05-20T18:28:54.915278+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4509,13 +4509,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e16728df",
+   "id": "c614e3d9",
    "metadata": {
     "papermill": {
-     "duration": 0.023889,
-     "end_time": "2026-05-20T16:33:22.589102+00:00",
+     "duration": 0.025779,
+     "end_time": "2026-05-20T18:28:55.025385+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:22.565213+00:00",
+     "start_time": "2026-05-20T18:28:54.999606+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4530,19 +4530,19 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "id": "4001550d",
+   "id": "c491ed80",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:33:22.639486Z",
-     "iopub.status.busy": "2026-05-20T16:33:22.639171Z",
-     "iopub.status.idle": "2026-05-20T16:33:22.644204Z",
-     "shell.execute_reply": "2026-05-20T16:33:22.643308Z"
+     "iopub.execute_input": "2026-05-20T18:28:55.075756Z",
+     "iopub.status.busy": "2026-05-20T18:28:55.075484Z",
+     "iopub.status.idle": "2026-05-20T18:28:55.081096Z",
+     "shell.execute_reply": "2026-05-20T18:28:55.080080Z"
     },
     "papermill": {
-     "duration": 0.032129,
-     "end_time": "2026-05-20T16:33:22.644992+00:00",
+     "duration": 0.032995,
+     "end_time": "2026-05-20T18:28:55.081838+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:22.612863+00:00",
+     "start_time": "2026-05-20T18:28:55.048843+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4556,19 +4556,19 @@
   {
    "cell_type": "code",
    "execution_count": 41,
-   "id": "f4dfff14",
+   "id": "dfee0dc0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:33:22.692260Z",
-     "iopub.status.busy": "2026-05-20T16:33:22.692080Z",
-     "iopub.status.idle": "2026-05-20T16:33:22.719792Z",
-     "shell.execute_reply": "2026-05-20T16:33:22.718970Z"
+     "iopub.execute_input": "2026-05-20T18:28:55.137894Z",
+     "iopub.status.busy": "2026-05-20T18:28:55.137595Z",
+     "iopub.status.idle": "2026-05-20T18:28:55.168558Z",
+     "shell.execute_reply": "2026-05-20T18:28:55.167416Z"
     },
     "papermill": {
-     "duration": 0.052124,
-     "end_time": "2026-05-20T16:33:22.720742+00:00",
+     "duration": 0.060225,
+     "end_time": "2026-05-20T18:28:55.169518+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:22.668618+00:00",
+     "start_time": "2026-05-20T18:28:55.109293+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4614,13 +4614,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f9920527",
+   "id": "353c6ea1",
    "metadata": {
     "papermill": {
-     "duration": 0.023964,
-     "end_time": "2026-05-20T16:33:22.769091+00:00",
+     "duration": 0.024756,
+     "end_time": "2026-05-20T18:28:55.224931+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:22.745127+00:00",
+     "start_time": "2026-05-20T18:28:55.200175+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4635,19 +4635,19 @@
   {
    "cell_type": "code",
    "execution_count": 42,
-   "id": "2c81dd2a",
+   "id": "13648e76",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:33:22.818762Z",
-     "iopub.status.busy": "2026-05-20T16:33:22.818509Z",
-     "iopub.status.idle": "2026-05-20T16:33:22.832732Z",
-     "shell.execute_reply": "2026-05-20T16:33:22.831652Z"
+     "iopub.execute_input": "2026-05-20T18:28:55.276771Z",
+     "iopub.status.busy": "2026-05-20T18:28:55.276498Z",
+     "iopub.status.idle": "2026-05-20T18:28:55.289912Z",
+     "shell.execute_reply": "2026-05-20T18:28:55.289008Z"
     },
     "papermill": {
-     "duration": 0.040905,
-     "end_time": "2026-05-20T16:33:22.833556+00:00",
+     "duration": 0.040127,
+     "end_time": "2026-05-20T18:28:55.290627+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:22.792651+00:00",
+     "start_time": "2026-05-20T18:28:55.250500+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4683,13 +4683,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3ed7e90c",
+   "id": "58a9f9ad",
    "metadata": {
     "papermill": {
-     "duration": 0.029276,
-     "end_time": "2026-05-20T16:33:22.889383+00:00",
+     "duration": 0.023938,
+     "end_time": "2026-05-20T18:28:55.339268+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:22.860107+00:00",
+     "start_time": "2026-05-20T18:28:55.315330+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4704,19 +4704,19 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "id": "b9ad9247",
+   "id": "78dc321b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:33:22.939718Z",
-     "iopub.status.busy": "2026-05-20T16:33:22.939511Z",
-     "iopub.status.idle": "2026-05-20T16:33:22.951675Z",
-     "shell.execute_reply": "2026-05-20T16:33:22.950698Z"
+     "iopub.execute_input": "2026-05-20T18:28:55.392069Z",
+     "iopub.status.busy": "2026-05-20T18:28:55.391846Z",
+     "iopub.status.idle": "2026-05-20T18:28:55.404887Z",
+     "shell.execute_reply": "2026-05-20T18:28:55.403766Z"
     },
     "papermill": {
-     "duration": 0.038444,
-     "end_time": "2026-05-20T16:33:22.952351+00:00",
+     "duration": 0.040187,
+     "end_time": "2026-05-20T18:28:55.405661+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:22.913907+00:00",
+     "start_time": "2026-05-20T18:28:55.365474+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4752,13 +4752,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a3ba52ff",
+   "id": "3373569f",
    "metadata": {
     "papermill": {
-     "duration": 0.191556,
-     "end_time": "2026-05-20T16:33:23.168534+00:00",
+     "duration": 0.025611,
+     "end_time": "2026-05-20T18:28:55.457825+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:22.976978+00:00",
+     "start_time": "2026-05-20T18:28:55.432214+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4769,13 +4769,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b4b059aa",
+   "id": "5c0291ec",
    "metadata": {
     "papermill": {
-     "duration": 0.024748,
-     "end_time": "2026-05-20T16:33:23.224743+00:00",
+     "duration": 0.025469,
+     "end_time": "2026-05-20T18:28:55.508411+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:23.199995+00:00",
+     "start_time": "2026-05-20T18:28:55.482942+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4790,19 +4790,19 @@
   {
    "cell_type": "code",
    "execution_count": 44,
-   "id": "211bbb6f",
+   "id": "f5d63b2f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:33:23.275406Z",
-     "iopub.status.busy": "2026-05-20T16:33:23.275221Z",
-     "iopub.status.idle": "2026-05-20T16:33:23.282810Z",
-     "shell.execute_reply": "2026-05-20T16:33:23.281982Z"
+     "iopub.execute_input": "2026-05-20T18:28:55.561541Z",
+     "iopub.status.busy": "2026-05-20T18:28:55.561307Z",
+     "iopub.status.idle": "2026-05-20T18:28:55.569779Z",
+     "shell.execute_reply": "2026-05-20T18:28:55.568622Z"
     },
     "papermill": {
-     "duration": 0.034684,
-     "end_time": "2026-05-20T16:33:23.283548+00:00",
+     "duration": 0.036656,
+     "end_time": "2026-05-20T18:28:55.570475+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:23.248864+00:00",
+     "start_time": "2026-05-20T18:28:55.533819+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4871,19 +4871,19 @@
   {
    "cell_type": "code",
    "execution_count": 45,
-   "id": "e972a1a2",
+   "id": "9cb84f27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:33:23.334406Z",
-     "iopub.status.busy": "2026-05-20T16:33:23.334194Z",
-     "iopub.status.idle": "2026-05-20T16:33:24.626156Z",
-     "shell.execute_reply": "2026-05-20T16:33:24.625176Z"
+     "iopub.execute_input": "2026-05-20T18:28:55.625548Z",
+     "iopub.status.busy": "2026-05-20T18:28:55.625268Z",
+     "iopub.status.idle": "2026-05-20T18:28:56.770888Z",
+     "shell.execute_reply": "2026-05-20T18:28:56.769883Z"
     },
     "papermill": {
-     "duration": 1.318343,
-     "end_time": "2026-05-20T16:33:24.627146+00:00",
+     "duration": 1.176005,
+     "end_time": "2026-05-20T18:28:56.771989+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:23.308803+00:00",
+     "start_time": "2026-05-20T18:28:55.595984+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4938,19 +4938,19 @@
   {
    "cell_type": "code",
    "execution_count": 46,
-   "id": "d1475b62",
+   "id": "c9b54672",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:33:24.681163Z",
-     "iopub.status.busy": "2026-05-20T16:33:24.680817Z",
-     "iopub.status.idle": "2026-05-20T16:33:25.801671Z",
-     "shell.execute_reply": "2026-05-20T16:33:25.800692Z"
+     "iopub.execute_input": "2026-05-20T18:28:56.830101Z",
+     "iopub.status.busy": "2026-05-20T18:28:56.829755Z",
+     "iopub.status.idle": "2026-05-20T18:28:57.988307Z",
+     "shell.execute_reply": "2026-05-20T18:28:57.987284Z"
     },
     "papermill": {
-     "duration": 1.148865,
-     "end_time": "2026-05-20T16:33:25.802717+00:00",
+     "duration": 1.188761,
+     "end_time": "2026-05-20T18:28:57.989501+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:24.653852+00:00",
+     "start_time": "2026-05-20T18:28:56.800740+00:00",
      "status": "completed"
     },
     "tags": []
@@ -5005,19 +5005,19 @@
   {
    "cell_type": "code",
    "execution_count": 47,
-   "id": "f06bbe0e",
+   "id": "22ae10b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:33:25.864374Z",
-     "iopub.status.busy": "2026-05-20T16:33:25.864142Z",
-     "iopub.status.idle": "2026-05-20T16:33:25.868334Z",
-     "shell.execute_reply": "2026-05-20T16:33:25.867468Z"
+     "iopub.execute_input": "2026-05-20T18:28:58.052499Z",
+     "iopub.status.busy": "2026-05-20T18:28:58.052118Z",
+     "iopub.status.idle": "2026-05-20T18:28:58.056459Z",
+     "shell.execute_reply": "2026-05-20T18:28:58.055572Z"
     },
     "papermill": {
-     "duration": 0.035735,
-     "end_time": "2026-05-20T16:33:25.869133+00:00",
+     "duration": 0.035449,
+     "end_time": "2026-05-20T18:28:58.057254+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:25.833398+00:00",
+     "start_time": "2026-05-20T18:28:58.021805+00:00",
      "status": "completed"
     },
     "tags": []
@@ -5036,13 +5036,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "72215cca",
+   "id": "b759784d",
    "metadata": {
     "papermill": {
-     "duration": 0.030292,
-     "end_time": "2026-05-20T16:33:25.931209+00:00",
+     "duration": 0.030969,
+     "end_time": "2026-05-20T18:28:58.117998+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:25.900917+00:00",
+     "start_time": "2026-05-20T18:28:58.087029+00:00",
      "status": "completed"
     },
     "tags": []
@@ -5060,19 +5060,19 @@
   {
    "cell_type": "code",
    "execution_count": 48,
-   "id": "0a4553bd",
+   "id": "657622d6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:33:25.990351Z",
-     "iopub.status.busy": "2026-05-20T16:33:25.990134Z",
-     "iopub.status.idle": "2026-05-20T16:34:39.779102Z",
-     "shell.execute_reply": "2026-05-20T16:34:39.777929Z"
+     "iopub.execute_input": "2026-05-20T18:28:58.180817Z",
+     "iopub.status.busy": "2026-05-20T18:28:58.180518Z",
+     "iopub.status.idle": "2026-05-20T18:30:11.401247Z",
+     "shell.execute_reply": "2026-05-20T18:30:11.400095Z"
     },
     "papermill": {
-     "duration": 73.820392,
-     "end_time": "2026-05-20T16:34:39.780521+00:00",
+     "duration": 73.254276,
+     "end_time": "2026-05-20T18:30:11.402223+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:33:25.960129+00:00",
+     "start_time": "2026-05-20T18:28:58.147947+00:00",
      "status": "completed"
     },
     "tags": []
@@ -5082,14 +5082,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:25.997\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:28:58.189\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:26.706\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:28:58.921\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -5116,14 +5116,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:30.278\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:02.596\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:31.023\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:03.369\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -5150,14 +5150,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:34.575\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:06.993\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:35.271\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:07.700\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -5184,14 +5184,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:38.820\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:11.280\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:39.501\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:11.976\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -5218,77 +5218,77 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:43.036\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:15.479\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:43.707\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:16.150\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:44.396\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:16.837\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:45.043\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:17.491\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:45.766\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:18.213\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:46.404\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:18.863\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:47.086\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:19.548\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:47.735\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:20.212\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:48.394\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:20.864\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:48.418\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:20.888\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:49.092\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:21.563\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -5315,77 +5315,77 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:53.778\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:25.128\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:54.457\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:25.804\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:55.145\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:26.490\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:55.790\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:27.135\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:56.527\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:27.864\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:57.171\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:28.525\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:57.868\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:29.219\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:58.521\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:29.879\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:59.176\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:30.534\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:59.214\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:30.558\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:33:59.900\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:31.231\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -5412,77 +5412,77 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:03.518\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:34.854\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:04.196\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:35.535\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:04.901\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:36.185\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:05.547\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:37.109\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:06.267\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:37.831\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:06.905\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:38.467\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:07.588\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:39.145\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:08.229\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:39.788\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:08.880\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:40.436\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:08.905\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:40.461\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:09.578\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:41.123\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -5509,77 +5509,77 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:13.142\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:44.671\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:13.820\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:45.367\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:14.512\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:46.049\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:15.160\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:46.697\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:15.888\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:47.422\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:16.528\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:48.054\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:17.222\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:48.733\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:17.871\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:49.374\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:18.525\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:50.021\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:18.552\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:50.045\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:19.228\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:50.713\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -5606,14 +5606,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:22.841\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-16 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:54.318\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-16 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:23.522\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:54.998\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -5640,14 +5640,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:27.057\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-16 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:58.577\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-16 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:27.732\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:29:59.248\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -5674,14 +5674,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:31.299\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-16 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:30:02.817\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-16 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:31.975\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:30:03.504\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -5708,14 +5708,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:35.555\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-16 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:30:07.130\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-16 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:36.229\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:30:07.818\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -5810,13 +5810,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e8aab2b4",
+   "id": "a42805c2",
    "metadata": {
     "papermill": {
-     "duration": 0.055271,
-     "end_time": "2026-05-20T16:34:39.894031+00:00",
+     "duration": 0.055927,
+     "end_time": "2026-05-20T18:30:11.519813+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:34:39.838760+00:00",
+     "start_time": "2026-05-20T18:30:11.463886+00:00",
      "status": "completed"
     },
     "tags": []
@@ -5828,18 +5828,20 @@
   {
    "cell_type": "code",
    "execution_count": 49,
-   "id": "88d26d4d",
+   "id": "1725edf8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T16:34:40.010146Z",
-     "iopub.status.busy": "2026-05-20T16:34:40.009873Z"
+     "iopub.execute_input": "2026-05-20T18:30:11.634312Z",
+     "iopub.status.busy": "2026-05-20T18:30:11.634040Z",
+     "iopub.status.idle": "2026-05-20T18:32:04.190682Z",
+     "shell.execute_reply": "2026-05-20T18:32:04.189386Z"
     },
     "papermill": {
-     "duration": null,
-     "end_time": null,
+     "duration": 112.673847,
+     "end_time": "2026-05-20T18:32:04.253088+00:00",
      "exception": false,
-     "start_time": "2026-05-20T16:34:39.953939+00:00",
-     "status": "running"
+     "start_time": "2026-05-20T18:30:11.579241+00:00",
+     "status": "completed"
     },
     "tags": []
    },
@@ -5848,35 +5850,119 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:40.637\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-17 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:30:12.267\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-17 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:41.269\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-18 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:30:12.899\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-18 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:41.914\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-19 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:30:13.536\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-19 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:34:46.506\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-20 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:30:17.821\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-20 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-20 09:35:08.658\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-17 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 11:30:40.083\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-17 00:00:00\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-05-20 11:30:40.744\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-18 00:00:00\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-05-20 11:30:41.378\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-19 00:00:00\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-05-20 11:30:45.644\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-20 00:00:00\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-05-20 11:31:08.144\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-17 00:00:00\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-05-20 11:31:08.822\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-18 00:00:00\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-05-20 11:31:09.478\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-19 00:00:00\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-05-20 11:31:13.785\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-20 00:00:00\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-05-20 11:31:36.792\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-17 00:00:00\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-05-20 11:31:37.464\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-18 00:00:00\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-05-20 11:31:38.117\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-19 00:00:00\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-05-20 11:31:42.396\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-20 00:00:00\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "All final YLD checks passed.\n"
      ]
     }
    ],
@@ -5934,52 +6020,96 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "6027cd76",
+   "execution_count": 50,
+   "id": "15354752",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-20T18:32:04.370335Z",
+     "iopub.status.busy": "2026-05-20T18:32:04.370035Z",
+     "iopub.status.idle": "2026-05-20T18:32:04.639957Z",
+     "shell.execute_reply": "2026-05-20T18:32:04.638932Z"
+    },
     "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
+     "duration": 0.32878,
+     "end_time": "2026-05-20T18:32:04.640924+00:00",
+     "exception": false,
+     "start_time": "2026-05-20T18:32:04.312144+00:00",
+     "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "anemia_status\n",
+       "mild           5381.886283\n",
+       "moderate       5699.991175\n",
+       "not_anemic    27177.965095\n",
+       "severe          888.383433\n",
+       "Name: value, dtype: float64"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "sim.get_results()['anemia_person_time'].groupby('anemia_status').value.sum()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "321732f5",
+   "execution_count": 51,
+   "id": "65114320",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-20T18:32:04.761871Z",
+     "iopub.status.busy": "2026-05-20T18:32:04.761311Z",
+     "iopub.status.idle": "2026-05-20T18:32:04.773533Z",
+     "shell.execute_reply": "2026-05-20T18:32:04.772629Z"
+    },
     "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
+     "duration": 0.07159,
+     "end_time": "2026-05-20T18:32:04.774277+00:00",
+     "exception": false,
+     "start_time": "2026-05-20T18:32:04.702687+00:00",
+     "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "hemoglobin.exposure\n",
+       "mild           946.710472\n",
+       "moderate      1030.997947\n",
+       "not_anemic    4727.227926\n",
+       "severe         181.453799\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "pd.Series(6 * 7 * (1 / 365.25), index=anemia_status[parent_survived_birth].index).groupby(anemia_status[parent_survived_birth]).sum().sort_index()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "8d66e320",
+   "id": "099083d4",
    "metadata": {
     "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
+     "duration": 0.058619,
+     "end_time": "2026-05-20T18:32:04.890754+00:00",
+     "exception": false,
+     "start_time": "2026-05-20T18:32:04.832135+00:00",
+     "status": "completed"
     },
     "tags": []
    },
@@ -5994,19 +6124,111 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e8ebc9e7",
+   "execution_count": 52,
+   "id": "fb60fc87",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-20T18:32:05.008511Z",
+     "iopub.status.busy": "2026-05-20T18:32:05.008263Z",
+     "iopub.status.idle": "2026-05-20T18:32:05.072487Z",
+     "shell.execute_reply": "2026-05-20T18:32:05.071482Z"
+    },
     "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
+     "duration": 0.12407,
+     "end_time": "2026-05-20T18:32:05.073374+00:00",
+     "exception": false,
+     "start_time": "2026-05-20T18:32:04.949304+00:00",
+     "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>count</th>\n",
+       "      <th>mean</th>\n",
+       "      <th>std</th>\n",
+       "      <th>min</th>\n",
+       "      <th>25%</th>\n",
+       "      <th>50%</th>\n",
+       "      <th>75%</th>\n",
+       "      <th>max</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>oral_iron_intervention_baseline</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>ifa</th>\n",
+       "      <td>22566.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>no_treatment</th>\n",
+       "      <td>37434.0</td>\n",
+       "      <td>3.751138</td>\n",
+       "      <td>4.811385</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>9.922281</td>\n",
+       "      <td>9.922281</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                   count      mean       std  min  25%  50%  \\\n",
+       "oral_iron_intervention_baseline                                               \n",
+       "ifa                              22566.0  0.000000  0.000000  0.0  0.0  0.0   \n",
+       "no_treatment                     37434.0  3.751138  4.811385  0.0  0.0  0.0   \n",
+       "\n",
+       "                                      75%       max  \n",
+       "oral_iron_intervention_baseline                      \n",
+       "ifa                              0.000000  0.000000  \n",
+       "no_treatment                     9.922281  9.922281  "
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "compare_population = final_pops['mms_total_scaleup'].join(\n",
     "    final_pops['baseline'],\n",
@@ -6066,15 +6288,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d3c45b44",
+   "execution_count": 53,
+   "id": "c9bf95cf",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-20T18:32:05.191080Z",
+     "iopub.status.busy": "2026-05-20T18:32:05.190537Z",
+     "iopub.status.idle": "2026-05-20T18:32:05.226658Z",
+     "shell.execute_reply": "2026-05-20T18:32:05.225726Z"
+    },
     "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
+     "duration": 0.095144,
+     "end_time": "2026-05-20T18:32:05.227701+00:00",
+     "exception": false,
+     "start_time": "2026-05-20T18:32:05.132557+00:00",
+     "status": "completed"
     },
     "tags": []
    },
@@ -6096,14 +6324,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e52a9879",
+   "id": "daf8f687",
    "metadata": {
     "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
+     "duration": 0.058813,
+     "end_time": "2026-05-20T18:32:05.347877+00:00",
+     "exception": false,
+     "start_time": "2026-05-20T18:32:05.289064+00:00",
+     "status": "completed"
     },
     "tags": []
    },
@@ -6131,14 +6359,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": null,
-   "end_time": null,
+   "duration": 617.505161,
+   "end_time": "2026-05-20T18:32:06.523160+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "/mnt/share/homes/hjafari/repos/vivarium_gates_mncnh/tests/model_notebooks/interactive/interactive_simulation_hemoglobin.ipynb",
    "output_path": "/mnt/share/homes/hjafari/repos/vivarium_gates_mncnh/tests/model_notebooks/interactive/executed/interactive_simulation_hemoglobin.ipynb",
    "parameters": {},
-   "start_time": "2026-05-20T16:26:17.789611+00:00",
+   "start_time": "2026-05-20T18:21:49.017999+00:00",
    "version": "2.7.0"
   }
  },

--- a/tests/model_notebooks/interactive/executed/interactive_simulation_hemoglobin.ipynb
+++ b/tests/model_notebooks/interactive/executed/interactive_simulation_hemoglobin.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "30fb61f1",
+   "id": "38440a2f",
    "metadata": {
     "papermill": {
-     "duration": 0.020515,
-     "end_time": "2026-05-19T21:40:15.382916+00:00",
+     "duration": 0.020498,
+     "end_time": "2026-05-20T16:26:19.235781+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:15.362401+00:00",
+     "start_time": "2026-05-20T16:26:19.215283+00:00",
      "status": "completed"
     },
     "tags": []
@@ -23,13 +23,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2174e0bb",
+   "id": "3cd5f42a",
    "metadata": {
     "papermill": {
-     "duration": 0.011583,
-     "end_time": "2026-05-19T21:40:15.405963+00:00",
+     "duration": 0.01162,
+     "end_time": "2026-05-20T16:26:19.259475+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:15.394380+00:00",
+     "start_time": "2026-05-20T16:26:19.247855+00:00",
      "status": "completed"
     },
     "tags": []
@@ -41,19 +41,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "fdfefb42",
+   "id": "97842676",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:15.430837Z",
-     "iopub.status.busy": "2026-05-19T21:40:15.430287Z",
-     "iopub.status.idle": "2026-05-19T21:40:17.678560Z",
-     "shell.execute_reply": "2026-05-19T21:40:17.677080Z"
+     "iopub.execute_input": "2026-05-20T16:26:19.283650Z",
+     "iopub.status.busy": "2026-05-20T16:26:19.283467Z",
+     "iopub.status.idle": "2026-05-20T16:26:21.888966Z",
+     "shell.execute_reply": "2026-05-20T16:26:21.887510Z"
     },
     "papermill": {
-     "duration": 2.261752,
-     "end_time": "2026-05-19T21:40:17.679304+00:00",
+     "duration": 2.618727,
+     "end_time": "2026-05-20T16:26:21.889751+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:15.417552+00:00",
+     "start_time": "2026-05-20T16:26:19.271024+00:00",
      "status": "completed"
     },
     "tags": []
@@ -67,19 +67,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "11465795",
+   "id": "2ba8b356",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:17.704193Z",
-     "iopub.status.busy": "2026-05-19T21:40:17.703759Z",
-     "iopub.status.idle": "2026-05-19T21:40:18.940360Z",
-     "shell.execute_reply": "2026-05-19T21:40:18.937239Z"
+     "iopub.execute_input": "2026-05-20T16:26:21.914773Z",
+     "iopub.status.busy": "2026-05-20T16:26:21.914421Z",
+     "iopub.status.idle": "2026-05-20T16:26:23.265771Z",
+     "shell.execute_reply": "2026-05-20T16:26:23.262501Z"
     },
     "papermill": {
-     "duration": 1.250953,
-     "end_time": "2026-05-19T21:40:18.942156+00:00",
+     "duration": 1.365529,
+     "end_time": "2026-05-20T16:26:23.267481+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:17.691203+00:00",
+     "start_time": "2026-05-20T16:26:21.901952+00:00",
      "status": "completed"
     },
     "tags": []
@@ -112,19 +112,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "4c55cc55",
+   "id": "5405e322",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:18.970318Z",
-     "iopub.status.busy": "2026-05-19T21:40:18.970096Z",
-     "iopub.status.idle": "2026-05-19T21:40:19.819507Z",
-     "shell.execute_reply": "2026-05-19T21:40:19.817280Z"
+     "iopub.execute_input": "2026-05-20T16:26:23.296043Z",
+     "iopub.status.busy": "2026-05-20T16:26:23.295790Z",
+     "iopub.status.idle": "2026-05-20T16:26:24.226295Z",
+     "shell.execute_reply": "2026-05-20T16:26:24.224098Z"
     },
     "papermill": {
-     "duration": 0.863755,
-     "end_time": "2026-05-19T21:40:19.821923+00:00",
+     "duration": 0.945277,
+     "end_time": "2026-05-20T16:26:24.228441+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:18.958168+00:00",
+     "start_time": "2026-05-20T16:26:23.283164+00:00",
      "status": "completed"
     },
     "tags": []
@@ -140,7 +140,7 @@
       "vivarium_build_utils==3.2.2\r\n",
       "vivarium_cluster_tools==3.1.4\r\n",
       "vivarium_dependencies==1.0.7\r\n",
-      "-e git+ssh://git@github.com/ihmeuw/vivarium_gates_mncnh.git@14f8fa92ad0d30ff2d378fd8eed994e43c009c98#egg=vivarium_gates_mncnh\r\n",
+      "-e git+ssh://git@github.com/ihmeuw/vivarium_gates_mncnh.git@0096ee26c33ca456df2b51be38ce84948cb6ee28#egg=vivarium_gates_mncnh\r\n",
       "vivarium_gbd_access==5.0.10\r\n",
       "vivarium_inputs==7.2.4\r\n",
       "vivarium_public_health==5.0.2\r\n",
@@ -155,19 +155,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "fcd3b713",
+   "id": "a0d729bf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:19.850915Z",
-     "iopub.status.busy": "2026-05-19T21:40:19.850663Z",
-     "iopub.status.idle": "2026-05-19T21:40:19.855425Z",
-     "shell.execute_reply": "2026-05-19T21:40:19.854307Z"
+     "iopub.execute_input": "2026-05-20T16:26:24.259754Z",
+     "iopub.status.busy": "2026-05-20T16:26:24.259429Z",
+     "iopub.status.idle": "2026-05-20T16:26:24.263740Z",
+     "shell.execute_reply": "2026-05-20T16:26:24.262912Z"
     },
     "papermill": {
-     "duration": 0.017991,
-     "end_time": "2026-05-19T21:40:19.856215+00:00",
+     "duration": 0.0183,
+     "end_time": "2026-05-20T16:26:24.264655+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:19.838224+00:00",
+     "start_time": "2026-05-20T16:26:24.246355+00:00",
      "status": "completed"
     },
     "tags": []
@@ -183,19 +183,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "e7772f32",
+   "id": "9d3362de",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:19.881533Z",
-     "iopub.status.busy": "2026-05-19T21:40:19.881300Z",
-     "iopub.status.idle": "2026-05-19T21:40:19.928021Z",
-     "shell.execute_reply": "2026-05-19T21:40:19.926959Z"
+     "iopub.execute_input": "2026-05-20T16:26:24.289588Z",
+     "iopub.status.busy": "2026-05-20T16:26:24.289289Z",
+     "iopub.status.idle": "2026-05-20T16:26:24.337641Z",
+     "shell.execute_reply": "2026-05-20T16:26:24.336566Z"
     },
     "papermill": {
-     "duration": 0.060202,
-     "end_time": "2026-05-19T21:40:19.928705+00:00",
+     "duration": 0.061921,
+     "end_time": "2026-05-20T16:26:24.338324+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:19.868503+00:00",
+     "start_time": "2026-05-20T16:26:24.276403+00:00",
      "status": "completed"
     },
     "tags": []
@@ -305,19 +305,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "6b729749",
+   "id": "fe5de127",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:19.952599Z",
-     "iopub.status.busy": "2026-05-19T21:40:19.952370Z",
-     "iopub.status.idle": "2026-05-19T21:40:22.563723Z",
-     "shell.execute_reply": "2026-05-19T21:40:22.562562Z"
+     "iopub.execute_input": "2026-05-20T16:26:24.363151Z",
+     "iopub.status.busy": "2026-05-20T16:26:24.362919Z",
+     "iopub.status.idle": "2026-05-20T16:26:26.867014Z",
+     "shell.execute_reply": "2026-05-20T16:26:26.866188Z"
     },
     "papermill": {
-     "duration": 2.6241,
-     "end_time": "2026-05-19T21:40:22.564435+00:00",
+     "duration": 2.5177,
+     "end_time": "2026-05-20T16:26:26.867873+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:19.940335+00:00",
+     "start_time": "2026-05-20T16:26:24.350173+00:00",
      "status": "completed"
     },
     "tags": []
@@ -344,19 +344,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "cb3d77cf",
+   "id": "3e3ee91f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:22.589677Z",
-     "iopub.status.busy": "2026-05-19T21:40:22.589452Z",
-     "iopub.status.idle": "2026-05-19T21:40:22.595169Z",
-     "shell.execute_reply": "2026-05-19T21:40:22.594240Z"
+     "iopub.execute_input": "2026-05-20T16:26:26.894245Z",
+     "iopub.status.busy": "2026-05-20T16:26:26.894005Z",
+     "iopub.status.idle": "2026-05-20T16:26:26.899771Z",
+     "shell.execute_reply": "2026-05-20T16:26:26.898820Z"
     },
     "papermill": {
-     "duration": 0.018926,
-     "end_time": "2026-05-19T21:40:22.595908+00:00",
+     "duration": 0.01969,
+     "end_time": "2026-05-20T16:26:26.900521+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:22.576982+00:00",
+     "start_time": "2026-05-20T16:26:26.880831+00:00",
      "status": "completed"
     },
     "tags": []
@@ -381,13 +381,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ac04fcbb",
+   "id": "812f7745",
    "metadata": {
     "papermill": {
-     "duration": 0.012179,
-     "end_time": "2026-05-19T21:40:22.619861+00:00",
+     "duration": 0.011624,
+     "end_time": "2026-05-20T16:26:26.924366+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:22.607682+00:00",
+     "start_time": "2026-05-20T16:26:26.912742+00:00",
      "status": "completed"
     },
     "tags": []
@@ -403,19 +403,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "3d43faa0",
+   "id": "ad813516",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:22.644426Z",
-     "iopub.status.busy": "2026-05-19T21:40:22.644204Z",
-     "iopub.status.idle": "2026-05-19T21:40:22.746949Z",
-     "shell.execute_reply": "2026-05-19T21:40:22.745998Z"
+     "iopub.execute_input": "2026-05-20T16:26:26.949727Z",
+     "iopub.status.busy": "2026-05-20T16:26:26.949505Z",
+     "iopub.status.idle": "2026-05-20T16:26:27.051652Z",
+     "shell.execute_reply": "2026-05-20T16:26:27.050872Z"
     },
     "papermill": {
-     "duration": 0.116055,
-     "end_time": "2026-05-19T21:40:22.747860+00:00",
+     "duration": 0.115835,
+     "end_time": "2026-05-20T16:26:27.052549+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:22.631805+00:00",
+     "start_time": "2026-05-20T16:26:26.936714+00:00",
      "status": "completed"
     },
     "tags": []
@@ -445,13 +445,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b023ec09",
+   "id": "3caa1419",
    "metadata": {
     "papermill": {
-     "duration": 0.011639,
-     "end_time": "2026-05-19T21:40:22.771435+00:00",
+     "duration": 0.012085,
+     "end_time": "2026-05-20T16:26:27.077032+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:22.759796+00:00",
+     "start_time": "2026-05-20T16:26:27.064947+00:00",
      "status": "completed"
     },
     "tags": []
@@ -467,19 +467,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "9a22fe42",
+   "id": "aeec0ee9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:22.795888Z",
-     "iopub.status.busy": "2026-05-19T21:40:22.795578Z",
-     "iopub.status.idle": "2026-05-19T21:40:22.851436Z",
-     "shell.execute_reply": "2026-05-19T21:40:22.850582Z"
+     "iopub.execute_input": "2026-05-20T16:26:27.102573Z",
+     "iopub.status.busy": "2026-05-20T16:26:27.102245Z",
+     "iopub.status.idle": "2026-05-20T16:26:27.158044Z",
+     "shell.execute_reply": "2026-05-20T16:26:27.157200Z"
     },
     "papermill": {
-     "duration": 0.068919,
-     "end_time": "2026-05-19T21:40:22.852145+00:00",
+     "duration": 0.069521,
+     "end_time": "2026-05-20T16:26:27.158762+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:22.783226+00:00",
+     "start_time": "2026-05-20T16:26:27.089241+00:00",
      "status": "completed"
     },
     "tags": []
@@ -507,19 +507,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "6e343232",
+   "id": "df078f99",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:22.878394Z",
-     "iopub.status.busy": "2026-05-19T21:40:22.878149Z",
-     "iopub.status.idle": "2026-05-19T21:40:22.934150Z",
-     "shell.execute_reply": "2026-05-19T21:40:22.932354Z"
+     "iopub.execute_input": "2026-05-20T16:26:27.184635Z",
+     "iopub.status.busy": "2026-05-20T16:26:27.184413Z",
+     "iopub.status.idle": "2026-05-20T16:26:27.220430Z",
+     "shell.execute_reply": "2026-05-20T16:26:27.219558Z"
     },
     "papermill": {
-     "duration": 0.070358,
-     "end_time": "2026-05-19T21:40:22.935188+00:00",
+     "duration": 0.04988,
+     "end_time": "2026-05-20T16:26:27.221128+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:22.864830+00:00",
+     "start_time": "2026-05-20T16:26:27.171248+00:00",
      "status": "completed"
     },
     "tags": []
@@ -544,13 +544,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6df12b34",
+   "id": "58cac0cb",
    "metadata": {
     "papermill": {
-     "duration": 0.013249,
-     "end_time": "2026-05-19T21:40:22.964738+00:00",
+     "duration": 0.012874,
+     "end_time": "2026-05-20T16:26:27.247722+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:22.951489+00:00",
+     "start_time": "2026-05-20T16:26:27.234848+00:00",
      "status": "completed"
     },
     "tags": []
@@ -566,19 +566,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "1b1763c1",
+   "id": "9783468a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:22.991978Z",
-     "iopub.status.busy": "2026-05-19T21:40:22.991396Z",
-     "iopub.status.idle": "2026-05-19T21:40:23.044208Z",
-     "shell.execute_reply": "2026-05-19T21:40:23.043196Z"
+     "iopub.execute_input": "2026-05-20T16:26:27.273665Z",
+     "iopub.status.busy": "2026-05-20T16:26:27.273452Z",
+     "iopub.status.idle": "2026-05-20T16:26:27.311189Z",
+     "shell.execute_reply": "2026-05-20T16:26:27.310420Z"
     },
     "papermill": {
-     "duration": 0.067629,
-     "end_time": "2026-05-19T21:40:23.045182+00:00",
+     "duration": 0.051896,
+     "end_time": "2026-05-20T16:26:27.312071+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:22.977553+00:00",
+     "start_time": "2026-05-20T16:26:27.260175+00:00",
      "status": "completed"
     },
     "tags": []
@@ -605,19 +605,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "a67d9d42",
+   "id": "ed76a4ca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:23.072342Z",
-     "iopub.status.busy": "2026-05-19T21:40:23.071841Z",
-     "iopub.status.idle": "2026-05-19T21:40:23.183208Z",
-     "shell.execute_reply": "2026-05-19T21:40:23.182195Z"
+     "iopub.execute_input": "2026-05-20T16:26:27.338565Z",
+     "iopub.status.busy": "2026-05-20T16:26:27.338353Z",
+     "iopub.status.idle": "2026-05-20T16:26:27.440369Z",
+     "shell.execute_reply": "2026-05-20T16:26:27.439522Z"
     },
     "papermill": {
-     "duration": 0.125344,
-     "end_time": "2026-05-19T21:40:23.184130+00:00",
+     "duration": 0.116385,
+     "end_time": "2026-05-20T16:26:27.441320+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:23.058786+00:00",
+     "start_time": "2026-05-20T16:26:27.324935+00:00",
      "status": "completed"
     },
     "tags": []
@@ -647,19 +647,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "f32f67b0",
+   "id": "efb7103f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:23.211997Z",
-     "iopub.status.busy": "2026-05-19T21:40:23.211793Z",
-     "iopub.status.idle": "2026-05-19T21:40:23.330683Z",
-     "shell.execute_reply": "2026-05-19T21:40:23.329703Z"
+     "iopub.execute_input": "2026-05-20T16:26:27.469053Z",
+     "iopub.status.busy": "2026-05-20T16:26:27.468722Z",
+     "iopub.status.idle": "2026-05-20T16:26:27.582214Z",
+     "shell.execute_reply": "2026-05-20T16:26:27.581347Z"
     },
     "papermill": {
-     "duration": 0.133382,
-     "end_time": "2026-05-19T21:40:23.331603+00:00",
+     "duration": 0.128311,
+     "end_time": "2026-05-20T16:26:27.583043+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:23.198221+00:00",
+     "start_time": "2026-05-20T16:26:27.454732+00:00",
      "status": "completed"
     },
     "tags": []
@@ -687,19 +687,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "ebe2cf8e",
+   "id": "23710260",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:23.358727Z",
-     "iopub.status.busy": "2026-05-19T21:40:23.358508Z",
-     "iopub.status.idle": "2026-05-19T21:40:23.579389Z",
-     "shell.execute_reply": "2026-05-19T21:40:23.578548Z"
+     "iopub.execute_input": "2026-05-20T16:26:27.610088Z",
+     "iopub.status.busy": "2026-05-20T16:26:27.609864Z",
+     "iopub.status.idle": "2026-05-20T16:26:27.830621Z",
+     "shell.execute_reply": "2026-05-20T16:26:27.829538Z"
     },
     "papermill": {
-     "duration": 0.23516,
-     "end_time": "2026-05-19T21:40:23.580387+00:00",
+     "duration": 0.234817,
+     "end_time": "2026-05-20T16:26:27.831299+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:23.345227+00:00",
+     "start_time": "2026-05-20T16:26:27.596482+00:00",
      "status": "completed"
     },
     "tags": []
@@ -737,19 +737,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "0c8d552e",
+   "id": "b0cd6c2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:23.607719Z",
-     "iopub.status.busy": "2026-05-19T21:40:23.607494Z",
-     "iopub.status.idle": "2026-05-19T21:40:23.843958Z",
-     "shell.execute_reply": "2026-05-19T21:40:23.842992Z"
+     "iopub.execute_input": "2026-05-20T16:26:27.857708Z",
+     "iopub.status.busy": "2026-05-20T16:26:27.857489Z",
+     "iopub.status.idle": "2026-05-20T16:26:28.085752Z",
+     "shell.execute_reply": "2026-05-20T16:26:28.084689Z"
     },
     "papermill": {
-     "duration": 0.250519,
-     "end_time": "2026-05-19T21:40:23.844947+00:00",
+     "duration": 0.242305,
+     "end_time": "2026-05-20T16:26:28.086433+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:23.594428+00:00",
+     "start_time": "2026-05-20T16:26:27.844128+00:00",
      "status": "completed"
     },
     "tags": []
@@ -783,19 +783,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "0f2cd17d",
+   "id": "2c7204dd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:23.873018Z",
-     "iopub.status.busy": "2026-05-19T21:40:23.872770Z",
-     "iopub.status.idle": "2026-05-19T21:40:23.910339Z",
-     "shell.execute_reply": "2026-05-19T21:40:23.909546Z"
+     "iopub.execute_input": "2026-05-20T16:26:28.113717Z",
+     "iopub.status.busy": "2026-05-20T16:26:28.113424Z",
+     "iopub.status.idle": "2026-05-20T16:26:28.151369Z",
+     "shell.execute_reply": "2026-05-20T16:26:28.150318Z"
     },
     "papermill": {
-     "duration": 0.052173,
-     "end_time": "2026-05-19T21:40:23.911242+00:00",
+     "duration": 0.052402,
+     "end_time": "2026-05-20T16:26:28.152019+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:23.859069+00:00",
+     "start_time": "2026-05-20T16:26:28.099617+00:00",
      "status": "completed"
     },
     "tags": []
@@ -821,13 +821,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d089c5c",
+   "id": "9487231e",
    "metadata": {
     "papermill": {
-     "duration": 0.012405,
-     "end_time": "2026-05-19T21:40:23.937255+00:00",
+     "duration": 0.013039,
+     "end_time": "2026-05-20T16:26:28.177919+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:23.924850+00:00",
+     "start_time": "2026-05-20T16:26:28.164880+00:00",
      "status": "completed"
     },
     "tags": []
@@ -843,19 +843,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "d2307560",
+   "id": "990e6663",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:23.963301Z",
-     "iopub.status.busy": "2026-05-19T21:40:23.963077Z",
-     "iopub.status.idle": "2026-05-19T21:40:25.759590Z",
-     "shell.execute_reply": "2026-05-19T21:40:25.758343Z"
+     "iopub.execute_input": "2026-05-20T16:26:28.204792Z",
+     "iopub.status.busy": "2026-05-20T16:26:28.204555Z",
+     "iopub.status.idle": "2026-05-20T16:26:29.880690Z",
+     "shell.execute_reply": "2026-05-20T16:26:29.879510Z"
     },
     "papermill": {
-     "duration": 1.810844,
-     "end_time": "2026-05-19T21:40:25.760590+00:00",
+     "duration": 1.690946,
+     "end_time": "2026-05-20T16:26:29.881666+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:23.949746+00:00",
+     "start_time": "2026-05-20T16:26:28.190720+00:00",
      "status": "completed"
     },
     "tags": []
@@ -899,19 +899,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "97407024",
+   "id": "bd17679d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:25.790453Z",
-     "iopub.status.busy": "2026-05-19T21:40:25.790154Z",
-     "iopub.status.idle": "2026-05-19T21:40:25.796612Z",
-     "shell.execute_reply": "2026-05-19T21:40:25.795516Z"
+     "iopub.execute_input": "2026-05-20T16:26:29.910065Z",
+     "iopub.status.busy": "2026-05-20T16:26:29.909831Z",
+     "iopub.status.idle": "2026-05-20T16:26:29.915525Z",
+     "shell.execute_reply": "2026-05-20T16:26:29.914636Z"
     },
     "papermill": {
-     "duration": 0.022381,
-     "end_time": "2026-05-19T21:40:25.797654+00:00",
+     "duration": 0.020908,
+     "end_time": "2026-05-20T16:26:29.916460+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:25.775273+00:00",
+     "start_time": "2026-05-20T16:26:29.895552+00:00",
      "status": "completed"
     },
     "tags": []
@@ -937,13 +937,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b3c7c30",
+   "id": "30d34ee1",
    "metadata": {
     "papermill": {
-     "duration": 0.013822,
-     "end_time": "2026-05-19T21:40:25.825372+00:00",
+     "duration": 0.013781,
+     "end_time": "2026-05-20T16:26:29.943530+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:25.811550+00:00",
+     "start_time": "2026-05-20T16:26:29.929749+00:00",
      "status": "completed"
     },
     "tags": []
@@ -959,19 +959,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "f221b11c",
+   "id": "4c0e2122",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:25.853079Z",
-     "iopub.status.busy": "2026-05-19T21:40:25.852698Z",
-     "iopub.status.idle": "2026-05-19T21:40:25.935216Z",
-     "shell.execute_reply": "2026-05-19T21:40:25.934148Z"
+     "iopub.execute_input": "2026-05-20T16:26:29.971088Z",
+     "iopub.status.busy": "2026-05-20T16:26:29.970904Z",
+     "iopub.status.idle": "2026-05-20T16:26:30.051556Z",
+     "shell.execute_reply": "2026-05-20T16:26:30.050756Z"
     },
     "papermill": {
-     "duration": 0.097539,
-     "end_time": "2026-05-19T21:40:25.936230+00:00",
+     "duration": 0.095775,
+     "end_time": "2026-05-20T16:26:30.052453+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:25.838691+00:00",
+     "start_time": "2026-05-20T16:26:29.956678+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1040,19 +1040,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "479618e3",
+   "id": "d5f1487f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:25.966239Z",
-     "iopub.status.busy": "2026-05-19T21:40:25.965926Z",
-     "iopub.status.idle": "2026-05-19T21:40:26.150564Z",
-     "shell.execute_reply": "2026-05-19T21:40:26.149643Z"
+     "iopub.execute_input": "2026-05-20T16:26:30.080920Z",
+     "iopub.status.busy": "2026-05-20T16:26:30.080602Z",
+     "iopub.status.idle": "2026-05-20T16:26:30.254698Z",
+     "shell.execute_reply": "2026-05-20T16:26:30.253926Z"
     },
     "papermill": {
-     "duration": 0.199585,
-     "end_time": "2026-05-19T21:40:26.151687+00:00",
+     "duration": 0.189356,
+     "end_time": "2026-05-20T16:26:30.255667+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:25.952102+00:00",
+     "start_time": "2026-05-20T16:26:30.066311+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1065,13 +1065,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4f20c7d2",
+   "id": "724e52c3",
    "metadata": {
     "papermill": {
-     "duration": 0.0134,
-     "end_time": "2026-05-19T21:40:26.180210+00:00",
+     "duration": 0.013375,
+     "end_time": "2026-05-20T16:26:30.282626+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:26.166810+00:00",
+     "start_time": "2026-05-20T16:26:30.269251+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1085,19 +1085,19 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "2a800267",
+   "id": "ce6d609f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:40:26.207556Z",
-     "iopub.status.busy": "2026-05-19T21:40:26.207238Z",
-     "iopub.status.idle": "2026-05-19T21:43:18.001979Z",
-     "shell.execute_reply": "2026-05-19T21:43:18.000874Z"
+     "iopub.execute_input": "2026-05-20T16:26:30.311548Z",
+     "iopub.status.busy": "2026-05-20T16:26:30.311322Z",
+     "iopub.status.idle": "2026-05-20T16:29:16.867099Z",
+     "shell.execute_reply": "2026-05-20T16:29:16.866066Z"
     },
     "papermill": {
-     "duration": 171.809607,
-     "end_time": "2026-05-19T21:43:18.002997+00:00",
+     "duration": 166.571699,
+     "end_time": "2026-05-20T16:29:16.868118+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:40:26.193390+00:00",
+     "start_time": "2026-05-20T16:26:30.296419+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1107,147 +1107,147 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:40:27.445\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:26:31.320\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:40:27.446\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:26:31.321\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:40:27.448\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:26:31.322\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:08.998\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:09.919\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:08.999\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:09.920\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:09.213\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:10.120\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:09.213\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:10.121\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:09.214\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:10.122\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:09.215\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:10.122\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:09.216\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:10.123\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:09.216\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:10.123\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:09.218\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:10.124\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:09.219\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:10.124\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:09.219\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:10.125\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:09.220\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:10.126\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:09.222\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:10.126\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:09.223\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:10.127\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:09.223\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:10.127\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:09.224\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:10.128\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:09.225\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:10.128\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:09.226\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
+      "\u001b[32m2026-05-20 09:27:10.129\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
       "['ferritin_screening_coverage', 'hemoglobin_screening_coverage', 'sex']\u001b[0m\n"
      ]
     },
@@ -1255,147 +1255,147 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:11.975\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:12.664\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:11.976\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:12.666\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:11.977\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:12.666\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:53.098\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:51.412\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:53.099\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:51.413\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:53.296\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:51.600\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:53.297\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:51.600\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:53.298\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:51.601\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:53.298\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:51.601\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:53.299\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:51.602\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:53.299\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:51.602\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:53.300\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:51.603\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:53.301\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:51.603\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:53.302\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:51.604\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:53.302\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:51.604\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:53.303\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:51.605\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:53.303\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:51.606\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:53.304\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:51.606\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:53.305\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:51.607\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:53.305\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:51.607\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:53.306\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
+      "\u001b[32m2026-05-20 09:27:51.608\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
       "['ferritin_screening_coverage', 'hemoglobin_screening_coverage', 'sex']\u001b[0m\n"
      ]
     },
@@ -1403,147 +1403,147 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:56.014\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:54.074\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:56.015\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:54.075\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:41:56.015\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:27:54.075\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:42:34.368\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:28:32.775\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:42:34.369\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:28:32.776\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:42:34.559\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:28:32.960\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:42:34.559\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:28:32.961\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:42:34.560\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:28:32.961\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:42:34.560\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:28:32.962\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:42:34.561\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:28:32.962\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:42:34.561\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:28:32.963\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:42:34.562\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:28:32.963\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:42:34.562\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:28:32.966\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:42:34.563\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:28:32.966\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:42:34.563\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:28:32.967\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:42:34.564\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:28:32.967\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:42:34.564\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:28:32.968\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:42:34.565\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:28:32.969\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:42:34.566\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:28:32.969\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:42:34.566\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:28:32.970\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:42:34.567\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
+      "\u001b[32m2026-05-20 09:28:32.973\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
       "['ferritin_screening_coverage', 'hemoglobin_screening_coverage', 'sex']\u001b[0m\n"
      ]
     },
@@ -1551,147 +1551,147 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:42:37.106\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:28:35.490\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m80\u001b[0m - \u001b[1mRunning simulation from artifact located at /mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/aph/ethiopia.hdf.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:42:37.107\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:28:35.490\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m81\u001b[0m - \u001b[1mArtifact base filter terms are ['draw == 60'].\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:42:37.107\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:28:35.491\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36martifact_manager\u001b[0m:\u001b[36m82\u001b[0m - \u001b[1mArtifact additional filter terms are None.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:43:15.412\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:29:14.298\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:43:15.412\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:29:14.298\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mresults_manager\u001b[0m:\u001b[36m409\u001b[0m - \u001b[33m\u001b[1mSpecified excluded stratifications are already not included by default: ['stillbirth', 'partial_term']\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:43:15.594\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:29:14.481\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:43:15.594\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:29:14.481\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:43:15.595\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:29:14.482\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.hemoglobin' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:43:15.595\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:29:14.482\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:43:15.596\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:29:14.483\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'ensemble_distribution_weights' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:43:15.596\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:29:14.483\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'exposure_standard_deviation' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:43:15.597\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:29:14.484\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_factor.low_birth_weight_and_short_gestation' configured, but didn't build lookup table 'birth_exposure' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:43:15.597\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:29:14.484\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.all_causes.all_cause_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:43:15.598\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:29:14.485\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:43:15.598\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:29:14.485\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:43:15.599\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:29:14.486\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:43:15.599\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:29:14.487\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'risk_effect.low_birth_weight_and_short_gestation_on_cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk' configured, but didn't build lookup table 'relative_risk' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:43:15.600\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:29:14.487\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.antepartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:43:15.601\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:29:14.488\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.postpartum_hemorrhage.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:43:15.601\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:29:14.488\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mlookup_table_manager\u001b[0m:\u001b[36m85\u001b[0m - \u001b[33m\u001b[1mComponent 'non_log_linear_risk_effect.hemoglobin_on_cause.maternal_sepsis_and_other_maternal_infections.incidence_risk' configured, but didn't build lookup table 'population_attributable_fraction' during setup.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:43:15.602\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
+      "\u001b[32m2026-05-20 09:29:14.489\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mresults_context\u001b[0m:\u001b[36m131\u001b[0m - \u001b[1mThe following stratifications are registered but not used by any observers: \n",
       "['ferritin_screening_coverage', 'hemoglobin_screening_coverage', 'sex']\u001b[0m\n"
      ]
     },
@@ -1748,13 +1748,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "604196bc",
+   "id": "c7537a0b",
    "metadata": {
     "papermill": {
-     "duration": 0.016402,
-     "end_time": "2026-05-19T21:43:18.037303+00:00",
+     "duration": 0.018621,
+     "end_time": "2026-05-20T16:29:16.906844+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:43:18.020901+00:00",
+     "start_time": "2026-05-20T16:29:16.888223+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1772,19 +1772,19 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "2b739dcf",
+   "id": "b06742d9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:43:18.072688Z",
-     "iopub.status.busy": "2026-05-19T21:43:18.072419Z",
-     "iopub.status.idle": "2026-05-19T21:43:23.216903Z",
-     "shell.execute_reply": "2026-05-19T21:43:23.215787Z"
+     "iopub.execute_input": "2026-05-20T16:29:16.942032Z",
+     "iopub.status.busy": "2026-05-20T16:29:16.941706Z",
+     "iopub.status.idle": "2026-05-20T16:29:21.831763Z",
+     "shell.execute_reply": "2026-05-20T16:29:21.830728Z"
     },
     "papermill": {
-     "duration": 5.164151,
-     "end_time": "2026-05-19T21:43:23.217914+00:00",
+     "duration": 4.908932,
+     "end_time": "2026-05-20T16:29:21.832829+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:43:18.053763+00:00",
+     "start_time": "2026-05-20T16:29:16.923897+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1836,13 +1836,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aaadce81",
+   "id": "0011ada3",
    "metadata": {
     "papermill": {
-     "duration": 0.017943,
-     "end_time": "2026-05-19T21:43:23.255477+00:00",
+     "duration": 0.016955,
+     "end_time": "2026-05-20T16:29:21.868046+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:43:23.237534+00:00",
+     "start_time": "2026-05-20T16:29:21.851091+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1869,19 +1869,19 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "1d545fff",
+   "id": "1fadd4b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:43:23.294405Z",
-     "iopub.status.busy": "2026-05-19T21:43:23.294147Z",
-     "iopub.status.idle": "2026-05-19T21:44:30.535603Z",
-     "shell.execute_reply": "2026-05-19T21:44:30.534222Z"
+     "iopub.execute_input": "2026-05-20T16:29:21.904488Z",
+     "iopub.status.busy": "2026-05-20T16:29:21.904277Z",
+     "iopub.status.idle": "2026-05-20T16:30:21.119022Z",
+     "shell.execute_reply": "2026-05-20T16:30:21.118174Z"
     },
     "papermill": {
-     "duration": 67.262131,
-     "end_time": "2026-05-19T21:44:30.536610+00:00",
+     "duration": 59.234268,
+     "end_time": "2026-05-20T16:30:21.119988+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:43:23.274479+00:00",
+     "start_time": "2026-05-20T16:29:21.885720+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1891,7 +1891,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:43:23.308\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:29:21.917\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -1936,7 +1936,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:43:39.798\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:29:36.634\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -1979,7 +1979,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:43:56.250\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:29:51.308\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -2024,7 +2024,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:44:13.106\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:30:06.162\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-01 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -2211,13 +2211,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65af6684",
+   "id": "2aa066b7",
    "metadata": {
     "papermill": {
-     "duration": 0.020435,
-     "end_time": "2026-05-19T21:44:30.579162+00:00",
+     "duration": 0.018866,
+     "end_time": "2026-05-20T16:30:21.157671+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:44:30.558727+00:00",
+     "start_time": "2026-05-20T16:30:21.138805+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2239,19 +2239,19 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "492f0697",
+   "id": "28acc1c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:44:30.624431Z",
-     "iopub.status.busy": "2026-05-19T21:44:30.624150Z",
-     "iopub.status.idle": "2026-05-19T21:44:38.633066Z",
-     "shell.execute_reply": "2026-05-19T21:44:38.632114Z"
+     "iopub.execute_input": "2026-05-20T16:30:21.196573Z",
+     "iopub.status.busy": "2026-05-20T16:30:21.196372Z",
+     "iopub.status.idle": "2026-05-20T16:30:28.113015Z",
+     "shell.execute_reply": "2026-05-20T16:30:28.112139Z"
     },
     "papermill": {
-     "duration": 8.032989,
-     "end_time": "2026-05-19T21:44:38.633941+00:00",
+     "duration": 6.937036,
+     "end_time": "2026-05-20T16:30:28.114113+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:44:30.600952+00:00",
+     "start_time": "2026-05-20T16:30:21.177077+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2261,7 +2261,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:44:30.633\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:30:21.203\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -2308,7 +2308,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:44:32.641\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:30:22.905\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -2355,7 +2355,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:44:34.658\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:30:24.583\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -2690,7 +2690,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:44:36.666\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:30:26.343\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-02 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -3092,13 +3092,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d27ff43d",
+   "id": "aaeac6f3",
    "metadata": {
     "papermill": {
-     "duration": 0.019432,
-     "end_time": "2026-05-19T21:44:38.675116+00:00",
+     "duration": 0.020611,
+     "end_time": "2026-05-20T16:30:28.156333+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:44:38.655684+00:00",
+     "start_time": "2026-05-20T16:30:28.135722+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3120,19 +3120,19 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "d0f32f18",
+   "id": "e5b47ef3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:44:38.715556Z",
-     "iopub.status.busy": "2026-05-19T21:44:38.715332Z",
-     "iopub.status.idle": "2026-05-19T21:44:51.249550Z",
-     "shell.execute_reply": "2026-05-19T21:44:51.248474Z"
+     "iopub.execute_input": "2026-05-20T16:30:28.199331Z",
+     "iopub.status.busy": "2026-05-20T16:30:28.199072Z",
+     "iopub.status.idle": "2026-05-20T16:30:39.112632Z",
+     "shell.execute_reply": "2026-05-20T16:30:39.111593Z"
     },
     "papermill": {
-     "duration": 12.555764,
-     "end_time": "2026-05-19T21:44:51.250632+00:00",
+     "duration": 10.936573,
+     "end_time": "2026-05-20T16:30:39.113845+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:44:38.694868+00:00",
+     "start_time": "2026-05-20T16:30:28.177272+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3142,7 +3142,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:44:39.431\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:30:28.832\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -3262,7 +3262,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:44:42.532\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:30:31.592\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -3382,7 +3382,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:44:45.684\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:30:34.245\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -3502,7 +3502,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:44:48.870\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:30:36.970\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-03 00:00:00\u001b[0m\n"
      ]
     },
     {
@@ -3708,13 +3708,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddbe1489",
+   "id": "90225df2",
    "metadata": {
     "papermill": {
-     "duration": 0.020349,
-     "end_time": "2026-05-19T21:44:51.293480+00:00",
+     "duration": 0.021183,
+     "end_time": "2026-05-20T16:30:39.157831+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:44:51.273131+00:00",
+     "start_time": "2026-05-20T16:30:39.136648+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3731,19 +3731,19 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "1d82884b",
+   "id": "10ebdf72",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:44:51.338193Z",
-     "iopub.status.busy": "2026-05-19T21:44:51.337874Z",
-     "iopub.status.idle": "2026-05-19T21:46:01.294073Z",
-     "shell.execute_reply": "2026-05-19T21:46:01.292961Z"
+     "iopub.execute_input": "2026-05-20T16:30:39.204500Z",
+     "iopub.status.busy": "2026-05-20T16:30:39.204116Z",
+     "iopub.status.idle": "2026-05-20T16:31:42.332201Z",
+     "shell.execute_reply": "2026-05-20T16:31:42.330925Z"
     },
     "papermill": {
-     "duration": 69.980322,
-     "end_time": "2026-05-19T21:46:01.295314+00:00",
+     "duration": 63.154283,
+     "end_time": "2026-05-20T16:31:42.333043+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:44:51.314992+00:00",
+     "start_time": "2026-05-20T16:30:39.178760+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3753,28 +3753,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:44:51.342\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:30:39.210\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:45:08.522\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:30:55.043\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:45:25.743\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:31:10.678\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:45:43.377\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:31:26.519\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-04 00:00:00\u001b[0m\n"
      ]
     }
    ],
@@ -3814,13 +3814,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b0b047b3",
+   "id": "46648f22",
    "metadata": {
     "papermill": {
-     "duration": 0.020993,
-     "end_time": "2026-05-19T21:46:01.340931+00:00",
+     "duration": 0.022596,
+     "end_time": "2026-05-20T16:31:42.380731+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:46:01.319938+00:00",
+     "start_time": "2026-05-20T16:31:42.358135+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3840,19 +3840,19 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "500dec4d",
+   "id": "a7d863c7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:46:01.385540Z",
-     "iopub.status.busy": "2026-05-19T21:46:01.385332Z",
-     "iopub.status.idle": "2026-05-19T21:47:41.065854Z",
-     "shell.execute_reply": "2026-05-19T21:47:41.064858Z"
+     "iopub.execute_input": "2026-05-20T16:31:42.425881Z",
+     "iopub.status.busy": "2026-05-20T16:31:42.425636Z",
+     "iopub.status.idle": "2026-05-20T16:33:19.226909Z",
+     "shell.execute_reply": "2026-05-20T16:33:19.225881Z"
     },
     "papermill": {
-     "duration": 99.705388,
-     "end_time": "2026-05-19T21:47:41.067149+00:00",
+     "duration": 96.825989,
+     "end_time": "2026-05-20T16:33:19.227861+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:46:01.361761+00:00",
+     "start_time": "2026-05-20T16:31:42.401872+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3862,28 +3862,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:46:01.392\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:31:42.432\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:46:25.877\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:32:05.762\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:46:50.835\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:32:28.872\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:47:16.460\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:32:52.612\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-05 00:00:00\u001b[0m\n"
      ]
     }
    ],
@@ -3946,19 +3946,19 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "e0235913",
+   "id": "358f6e8e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:47:41.117316Z",
-     "iopub.status.busy": "2026-05-19T21:47:41.117058Z",
-     "iopub.status.idle": "2026-05-19T21:47:41.174545Z",
-     "shell.execute_reply": "2026-05-19T21:47:41.172964Z"
+     "iopub.execute_input": "2026-05-20T16:33:19.273497Z",
+     "iopub.status.busy": "2026-05-20T16:33:19.273262Z",
+     "iopub.status.idle": "2026-05-20T16:33:19.323359Z",
+     "shell.execute_reply": "2026-05-20T16:33:19.322202Z"
     },
     "papermill": {
-     "duration": 0.082986,
-     "end_time": "2026-05-19T21:47:41.175329+00:00",
+     "duration": 0.074728,
+     "end_time": "2026-05-20T16:33:19.324609+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:41.092343+00:00",
+     "start_time": "2026-05-20T16:33:19.249881+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3995,19 +3995,19 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "4f5935a6",
+   "id": "aca8cf45",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:47:41.224286Z",
-     "iopub.status.busy": "2026-05-19T21:47:41.223939Z",
-     "iopub.status.idle": "2026-05-19T21:47:43.494038Z",
-     "shell.execute_reply": "2026-05-19T21:47:43.492502Z"
+     "iopub.execute_input": "2026-05-20T16:33:19.372909Z",
+     "iopub.status.busy": "2026-05-20T16:33:19.372596Z",
+     "iopub.status.idle": "2026-05-20T16:33:21.319088Z",
+     "shell.execute_reply": "2026-05-20T16:33:21.317987Z"
     },
     "papermill": {
-     "duration": 2.29491,
-     "end_time": "2026-05-19T21:47:43.494847+00:00",
+     "duration": 1.971724,
+     "end_time": "2026-05-20T16:33:21.320152+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:41.199937+00:00",
+     "start_time": "2026-05-20T16:33:19.348428+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4034,19 +4034,19 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "a939a259",
+   "id": "8b238979",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:47:43.544910Z",
-     "iopub.status.busy": "2026-05-19T21:47:43.544273Z",
-     "iopub.status.idle": "2026-05-19T21:47:43.557317Z",
-     "shell.execute_reply": "2026-05-19T21:47:43.556339Z"
+     "iopub.execute_input": "2026-05-20T16:33:21.366275Z",
+     "iopub.status.busy": "2026-05-20T16:33:21.366073Z",
+     "iopub.status.idle": "2026-05-20T16:33:21.377342Z",
+     "shell.execute_reply": "2026-05-20T16:33:21.376537Z"
     },
     "papermill": {
-     "duration": 0.038418,
-     "end_time": "2026-05-19T21:47:43.558416+00:00",
+     "duration": 0.034339,
+     "end_time": "2026-05-20T16:33:21.378219+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:43.519998+00:00",
+     "start_time": "2026-05-20T16:33:21.343880+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4058,13 +4058,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a43caf59",
+   "id": "e0fe5b29",
    "metadata": {
     "papermill": {
-     "duration": 0.023982,
-     "end_time": "2026-05-19T21:47:43.608856+00:00",
+     "duration": 0.023717,
+     "end_time": "2026-05-20T16:33:21.424439+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:43.584874+00:00",
+     "start_time": "2026-05-20T16:33:21.400722+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4078,19 +4078,19 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "id": "76cbb9c7",
+   "id": "8dfb3eea",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:47:43.658375Z",
-     "iopub.status.busy": "2026-05-19T21:47:43.658114Z",
-     "iopub.status.idle": "2026-05-19T21:47:43.690921Z",
-     "shell.execute_reply": "2026-05-19T21:47:43.689799Z"
+     "iopub.execute_input": "2026-05-20T16:33:21.473592Z",
+     "iopub.status.busy": "2026-05-20T16:33:21.473365Z",
+     "iopub.status.idle": "2026-05-20T16:33:21.501713Z",
+     "shell.execute_reply": "2026-05-20T16:33:21.500394Z"
     },
     "papermill": {
-     "duration": 0.058589,
-     "end_time": "2026-05-19T21:47:43.691747+00:00",
+     "duration": 0.054052,
+     "end_time": "2026-05-20T16:33:21.502503+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:43.633158+00:00",
+     "start_time": "2026-05-20T16:33:21.448451+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4124,13 +4124,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e2a20a8a",
+   "id": "12b23d96",
    "metadata": {
     "papermill": {
-     "duration": 0.022372,
-     "end_time": "2026-05-19T21:47:43.739994+00:00",
+     "duration": 0.022562,
+     "end_time": "2026-05-20T16:33:21.548502+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:43.717622+00:00",
+     "start_time": "2026-05-20T16:33:21.525940+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4145,19 +4145,19 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "24e34e06",
+   "id": "6e256461",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:47:43.790527Z",
-     "iopub.status.busy": "2026-05-19T21:47:43.790251Z",
-     "iopub.status.idle": "2026-05-19T21:47:43.794138Z",
-     "shell.execute_reply": "2026-05-19T21:47:43.793069Z"
+     "iopub.execute_input": "2026-05-20T16:33:21.595631Z",
+     "iopub.status.busy": "2026-05-20T16:33:21.595315Z",
+     "iopub.status.idle": "2026-05-20T16:33:21.599232Z",
+     "shell.execute_reply": "2026-05-20T16:33:21.598174Z"
     },
     "papermill": {
-     "duration": 0.030158,
-     "end_time": "2026-05-19T21:47:43.794871+00:00",
+     "duration": 0.028605,
+     "end_time": "2026-05-20T16:33:21.599936+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:43.764713+00:00",
+     "start_time": "2026-05-20T16:33:21.571331+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4171,19 +4171,19 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "id": "d5a09fea",
+   "id": "f2f55281",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:47:43.848740Z",
-     "iopub.status.busy": "2026-05-19T21:47:43.848393Z",
-     "iopub.status.idle": "2026-05-19T21:47:43.950176Z",
-     "shell.execute_reply": "2026-05-19T21:47:43.948065Z"
+     "iopub.execute_input": "2026-05-20T16:33:21.646056Z",
+     "iopub.status.busy": "2026-05-20T16:33:21.645841Z",
+     "iopub.status.idle": "2026-05-20T16:33:21.726097Z",
+     "shell.execute_reply": "2026-05-20T16:33:21.725009Z"
     },
     "papermill": {
-     "duration": 0.128722,
-     "end_time": "2026-05-19T21:47:43.950966+00:00",
+     "duration": 0.104937,
+     "end_time": "2026-05-20T16:33:21.727253+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:43.822244+00:00",
+     "start_time": "2026-05-20T16:33:21.622316+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4197,19 +4197,19 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "id": "8d198347",
+   "id": "8e231338",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:47:44.003003Z",
-     "iopub.status.busy": "2026-05-19T21:47:44.002445Z",
-     "iopub.status.idle": "2026-05-19T21:47:44.008006Z",
-     "shell.execute_reply": "2026-05-19T21:47:44.007034Z"
+     "iopub.execute_input": "2026-05-20T16:33:21.774110Z",
+     "iopub.status.busy": "2026-05-20T16:33:21.773871Z",
+     "iopub.status.idle": "2026-05-20T16:33:21.778844Z",
+     "shell.execute_reply": "2026-05-20T16:33:21.777898Z"
     },
     "papermill": {
-     "duration": 0.032942,
-     "end_time": "2026-05-19T21:47:44.008842+00:00",
+     "duration": 0.028959,
+     "end_time": "2026-05-20T16:33:21.779628+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:43.975900+00:00",
+     "start_time": "2026-05-20T16:33:21.750669+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4233,19 +4233,19 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "id": "1b996b28",
+   "id": "25bdddeb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:47:44.060155Z",
-     "iopub.status.busy": "2026-05-19T21:47:44.059843Z",
-     "iopub.status.idle": "2026-05-19T21:47:44.089570Z",
-     "shell.execute_reply": "2026-05-19T21:47:44.088233Z"
+     "iopub.execute_input": "2026-05-20T16:33:21.825523Z",
+     "iopub.status.busy": "2026-05-20T16:33:21.825305Z",
+     "iopub.status.idle": "2026-05-20T16:33:21.848473Z",
+     "shell.execute_reply": "2026-05-20T16:33:21.847391Z"
     },
     "papermill": {
-     "duration": 0.055657,
-     "end_time": "2026-05-19T21:47:44.090732+00:00",
+     "duration": 0.048102,
+     "end_time": "2026-05-20T16:33:21.849209+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:44.035075+00:00",
+     "start_time": "2026-05-20T16:33:21.801107+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4273,19 +4273,19 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "id": "10e41095",
+   "id": "9b0a7040",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:47:44.144417Z",
-     "iopub.status.busy": "2026-05-19T21:47:44.144014Z",
-     "iopub.status.idle": "2026-05-19T21:47:44.518639Z",
-     "shell.execute_reply": "2026-05-19T21:47:44.517751Z"
+     "iopub.execute_input": "2026-05-20T16:33:21.900224Z",
+     "iopub.status.busy": "2026-05-20T16:33:21.899975Z",
+     "iopub.status.idle": "2026-05-20T16:33:22.233761Z",
+     "shell.execute_reply": "2026-05-20T16:33:22.232937Z"
     },
     "papermill": {
-     "duration": 0.402691,
-     "end_time": "2026-05-19T21:47:44.519614+00:00",
+     "duration": 0.361709,
+     "end_time": "2026-05-20T16:33:22.234660+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:44.116923+00:00",
+     "start_time": "2026-05-20T16:33:21.872951+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4331,13 +4331,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ebff743e",
+   "id": "f7a31528",
    "metadata": {
     "papermill": {
-     "duration": 0.025458,
-     "end_time": "2026-05-19T21:47:44.570438+00:00",
+     "duration": 0.022118,
+     "end_time": "2026-05-20T16:33:22.281614+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:44.544980+00:00",
+     "start_time": "2026-05-20T16:33:22.259496+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4353,19 +4353,19 @@
   {
    "cell_type": "code",
    "execution_count": 37,
-   "id": "51515fd3",
+   "id": "6d422724",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:47:44.623572Z",
-     "iopub.status.busy": "2026-05-19T21:47:44.623259Z",
-     "iopub.status.idle": "2026-05-19T21:47:44.628805Z",
-     "shell.execute_reply": "2026-05-19T21:47:44.627767Z"
+     "iopub.execute_input": "2026-05-20T16:33:22.329888Z",
+     "iopub.status.busy": "2026-05-20T16:33:22.329618Z",
+     "iopub.status.idle": "2026-05-20T16:33:22.334732Z",
+     "shell.execute_reply": "2026-05-20T16:33:22.333737Z"
     },
     "papermill": {
-     "duration": 0.032958,
-     "end_time": "2026-05-19T21:47:44.629660+00:00",
+     "duration": 0.030597,
+     "end_time": "2026-05-20T16:33:22.335592+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:44.596702+00:00",
+     "start_time": "2026-05-20T16:33:22.304995+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4389,19 +4389,19 @@
   {
    "cell_type": "code",
    "execution_count": 38,
-   "id": "3d9e086b",
+   "id": "98d67baf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:47:44.686466Z",
-     "iopub.status.busy": "2026-05-19T21:47:44.686186Z",
-     "iopub.status.idle": "2026-05-19T21:47:44.716175Z",
-     "shell.execute_reply": "2026-05-19T21:47:44.715005Z"
+     "iopub.execute_input": "2026-05-20T16:33:22.387298Z",
+     "iopub.status.busy": "2026-05-20T16:33:22.387081Z",
+     "iopub.status.idle": "2026-05-20T16:33:22.412457Z",
+     "shell.execute_reply": "2026-05-20T16:33:22.411488Z"
     },
     "papermill": {
-     "duration": 0.06211,
-     "end_time": "2026-05-19T21:47:44.717033+00:00",
+     "duration": 0.050633,
+     "end_time": "2026-05-20T16:33:22.413194+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:44.654923+00:00",
+     "start_time": "2026-05-20T16:33:22.362561+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4438,13 +4438,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cabec2a8",
+   "id": "7a1b4ed5",
    "metadata": {
     "papermill": {
-     "duration": 0.025192,
-     "end_time": "2026-05-19T21:47:44.769001+00:00",
+     "duration": 0.024765,
+     "end_time": "2026-05-20T16:33:22.463846+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:44.743809+00:00",
+     "start_time": "2026-05-20T16:33:22.439081+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4460,19 +4460,19 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "id": "ca8a78cc",
+   "id": "264e48a7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:47:44.823620Z",
-     "iopub.status.busy": "2026-05-19T21:47:44.823325Z",
-     "iopub.status.idle": "2026-05-19T21:47:44.853518Z",
-     "shell.execute_reply": "2026-05-19T21:47:44.852310Z"
+     "iopub.execute_input": "2026-05-20T16:33:22.512880Z",
+     "iopub.status.busy": "2026-05-20T16:33:22.512595Z",
+     "iopub.status.idle": "2026-05-20T16:33:22.540176Z",
+     "shell.execute_reply": "2026-05-20T16:33:22.539150Z"
     },
     "papermill": {
-     "duration": 0.060351,
-     "end_time": "2026-05-19T21:47:44.854369+00:00",
+     "duration": 0.053175,
+     "end_time": "2026-05-20T16:33:22.540986+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:44.794018+00:00",
+     "start_time": "2026-05-20T16:33:22.487811+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4509,13 +4509,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c6b1d76d",
+   "id": "e16728df",
    "metadata": {
     "papermill": {
-     "duration": 0.026024,
-     "end_time": "2026-05-19T21:47:44.907766+00:00",
+     "duration": 0.023889,
+     "end_time": "2026-05-20T16:33:22.589102+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:44.881742+00:00",
+     "start_time": "2026-05-20T16:33:22.565213+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4530,19 +4530,19 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "id": "47463fa2",
+   "id": "4001550d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:47:44.962304Z",
-     "iopub.status.busy": "2026-05-19T21:47:44.962042Z",
-     "iopub.status.idle": "2026-05-19T21:47:44.968499Z",
-     "shell.execute_reply": "2026-05-19T21:47:44.967434Z"
+     "iopub.execute_input": "2026-05-20T16:33:22.639486Z",
+     "iopub.status.busy": "2026-05-20T16:33:22.639171Z",
+     "iopub.status.idle": "2026-05-20T16:33:22.644204Z",
+     "shell.execute_reply": "2026-05-20T16:33:22.643308Z"
     },
     "papermill": {
-     "duration": 0.034906,
-     "end_time": "2026-05-19T21:47:44.969433+00:00",
+     "duration": 0.032129,
+     "end_time": "2026-05-20T16:33:22.644992+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:44.934527+00:00",
+     "start_time": "2026-05-20T16:33:22.612863+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4556,19 +4556,19 @@
   {
    "cell_type": "code",
    "execution_count": 41,
-   "id": "a3662f6d",
+   "id": "f4dfff14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:47:45.024974Z",
-     "iopub.status.busy": "2026-05-19T21:47:45.024713Z",
-     "iopub.status.idle": "2026-05-19T21:47:45.059113Z",
-     "shell.execute_reply": "2026-05-19T21:47:45.057869Z"
+     "iopub.execute_input": "2026-05-20T16:33:22.692260Z",
+     "iopub.status.busy": "2026-05-20T16:33:22.692080Z",
+     "iopub.status.idle": "2026-05-20T16:33:22.719792Z",
+     "shell.execute_reply": "2026-05-20T16:33:22.718970Z"
     },
     "papermill": {
-     "duration": 0.062465,
-     "end_time": "2026-05-19T21:47:45.059895+00:00",
+     "duration": 0.052124,
+     "end_time": "2026-05-20T16:33:22.720742+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:44.997430+00:00",
+     "start_time": "2026-05-20T16:33:22.668618+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4614,13 +4614,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "825dc870",
+   "id": "f9920527",
    "metadata": {
     "papermill": {
-     "duration": 0.025379,
-     "end_time": "2026-05-19T21:47:45.111408+00:00",
+     "duration": 0.023964,
+     "end_time": "2026-05-20T16:33:22.769091+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:45.086029+00:00",
+     "start_time": "2026-05-20T16:33:22.745127+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4635,19 +4635,19 @@
   {
    "cell_type": "code",
    "execution_count": 42,
-   "id": "28da0387",
+   "id": "2c81dd2a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:47:45.163444Z",
-     "iopub.status.busy": "2026-05-19T21:47:45.163110Z",
-     "iopub.status.idle": "2026-05-19T21:47:45.178763Z",
-     "shell.execute_reply": "2026-05-19T21:47:45.177721Z"
+     "iopub.execute_input": "2026-05-20T16:33:22.818762Z",
+     "iopub.status.busy": "2026-05-20T16:33:22.818509Z",
+     "iopub.status.idle": "2026-05-20T16:33:22.832732Z",
+     "shell.execute_reply": "2026-05-20T16:33:22.831652Z"
     },
     "papermill": {
-     "duration": 0.042355,
-     "end_time": "2026-05-19T21:47:45.179544+00:00",
+     "duration": 0.040905,
+     "end_time": "2026-05-20T16:33:22.833556+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:45.137189+00:00",
+     "start_time": "2026-05-20T16:33:22.792651+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4683,13 +4683,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5cb3c09d",
+   "id": "3ed7e90c",
    "metadata": {
     "papermill": {
-     "duration": 0.025183,
-     "end_time": "2026-05-19T21:47:45.230451+00:00",
+     "duration": 0.029276,
+     "end_time": "2026-05-20T16:33:22.889383+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:45.205268+00:00",
+     "start_time": "2026-05-20T16:33:22.860107+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4704,19 +4704,19 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "id": "5395ed55",
+   "id": "b9ad9247",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:47:45.284020Z",
-     "iopub.status.busy": "2026-05-19T21:47:45.283749Z",
-     "iopub.status.idle": "2026-05-19T21:47:45.298483Z",
-     "shell.execute_reply": "2026-05-19T21:47:45.297400Z"
+     "iopub.execute_input": "2026-05-20T16:33:22.939718Z",
+     "iopub.status.busy": "2026-05-20T16:33:22.939511Z",
+     "iopub.status.idle": "2026-05-20T16:33:22.951675Z",
+     "shell.execute_reply": "2026-05-20T16:33:22.950698Z"
     },
     "papermill": {
-     "duration": 0.043373,
-     "end_time": "2026-05-19T21:47:45.299385+00:00",
+     "duration": 0.038444,
+     "end_time": "2026-05-20T16:33:22.952351+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:45.256012+00:00",
+     "start_time": "2026-05-20T16:33:22.913907+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4752,13 +4752,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bfe0b45e",
+   "id": "a3ba52ff",
    "metadata": {
     "papermill": {
-     "duration": 0.026713,
-     "end_time": "2026-05-19T21:47:45.355123+00:00",
+     "duration": 0.191556,
+     "end_time": "2026-05-20T16:33:23.168534+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:45.328410+00:00",
+     "start_time": "2026-05-20T16:33:22.976978+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4769,13 +4769,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fbc20df6",
+   "id": "b4b059aa",
    "metadata": {
     "papermill": {
-     "duration": 0.026062,
-     "end_time": "2026-05-19T21:47:45.407256+00:00",
+     "duration": 0.024748,
+     "end_time": "2026-05-20T16:33:23.224743+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:45.381194+00:00",
+     "start_time": "2026-05-20T16:33:23.199995+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4790,19 +4790,19 @@
   {
    "cell_type": "code",
    "execution_count": 44,
-   "id": "197a7489",
+   "id": "211bbb6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:47:45.459265Z",
-     "iopub.status.busy": "2026-05-19T21:47:45.458963Z",
-     "iopub.status.idle": "2026-05-19T21:47:45.468172Z",
-     "shell.execute_reply": "2026-05-19T21:47:45.467232Z"
+     "iopub.execute_input": "2026-05-20T16:33:23.275406Z",
+     "iopub.status.busy": "2026-05-20T16:33:23.275221Z",
+     "iopub.status.idle": "2026-05-20T16:33:23.282810Z",
+     "shell.execute_reply": "2026-05-20T16:33:23.281982Z"
     },
     "papermill": {
-     "duration": 0.036881,
-     "end_time": "2026-05-19T21:47:45.469010+00:00",
+     "duration": 0.034684,
+     "end_time": "2026-05-20T16:33:23.283548+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:45.432129+00:00",
+     "start_time": "2026-05-20T16:33:23.248864+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4871,19 +4871,19 @@
   {
    "cell_type": "code",
    "execution_count": 45,
-   "id": "1789dc9d",
+   "id": "e972a1a2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:47:45.525539Z",
-     "iopub.status.busy": "2026-05-19T21:47:45.525226Z",
-     "iopub.status.idle": "2026-05-19T21:47:46.966906Z",
-     "shell.execute_reply": "2026-05-19T21:47:46.965571Z"
+     "iopub.execute_input": "2026-05-20T16:33:23.334406Z",
+     "iopub.status.busy": "2026-05-20T16:33:23.334194Z",
+     "iopub.status.idle": "2026-05-20T16:33:24.626156Z",
+     "shell.execute_reply": "2026-05-20T16:33:24.625176Z"
     },
     "papermill": {
-     "duration": 1.470879,
-     "end_time": "2026-05-19T21:47:46.967738+00:00",
+     "duration": 1.318343,
+     "end_time": "2026-05-20T16:33:24.627146+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:45.496859+00:00",
+     "start_time": "2026-05-20T16:33:23.308803+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4938,19 +4938,19 @@
   {
    "cell_type": "code",
    "execution_count": 46,
-   "id": "93e6332b",
+   "id": "d1475b62",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:47:47.030432Z",
-     "iopub.status.busy": "2026-05-19T21:47:47.029832Z",
-     "iopub.status.idle": "2026-05-19T21:47:48.307419Z",
-     "shell.execute_reply": "2026-05-19T21:47:48.306518Z"
+     "iopub.execute_input": "2026-05-20T16:33:24.681163Z",
+     "iopub.status.busy": "2026-05-20T16:33:24.680817Z",
+     "iopub.status.idle": "2026-05-20T16:33:25.801671Z",
+     "shell.execute_reply": "2026-05-20T16:33:25.800692Z"
     },
     "papermill": {
-     "duration": 1.310159,
-     "end_time": "2026-05-19T21:47:48.308468+00:00",
+     "duration": 1.148865,
+     "end_time": "2026-05-20T16:33:25.802717+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:46.998309+00:00",
+     "start_time": "2026-05-20T16:33:24.653852+00:00",
      "status": "completed"
     },
     "tags": []
@@ -5005,19 +5005,19 @@
   {
    "cell_type": "code",
    "execution_count": 47,
-   "id": "8d783917",
+   "id": "f06bbe0e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:47:48.378928Z",
-     "iopub.status.busy": "2026-05-19T21:47:48.378370Z",
-     "iopub.status.idle": "2026-05-19T21:47:48.383469Z",
-     "shell.execute_reply": "2026-05-19T21:47:48.382518Z"
+     "iopub.execute_input": "2026-05-20T16:33:25.864374Z",
+     "iopub.status.busy": "2026-05-20T16:33:25.864142Z",
+     "iopub.status.idle": "2026-05-20T16:33:25.868334Z",
+     "shell.execute_reply": "2026-05-20T16:33:25.867468Z"
     },
     "papermill": {
-     "duration": 0.040958,
-     "end_time": "2026-05-19T21:47:48.384286+00:00",
+     "duration": 0.035735,
+     "end_time": "2026-05-20T16:33:25.869133+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:48.343328+00:00",
+     "start_time": "2026-05-20T16:33:25.833398+00:00",
      "status": "completed"
     },
     "tags": []
@@ -5036,13 +5036,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6ab1d8b1",
+   "id": "72215cca",
    "metadata": {
     "papermill": {
-     "duration": 0.034839,
-     "end_time": "2026-05-19T21:47:48.458813+00:00",
+     "duration": 0.030292,
+     "end_time": "2026-05-20T16:33:25.931209+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:48.423974+00:00",
+     "start_time": "2026-05-20T16:33:25.900917+00:00",
      "status": "completed"
     },
     "tags": []
@@ -5060,19 +5060,19 @@
   {
    "cell_type": "code",
    "execution_count": 48,
-   "id": "87c62387",
+   "id": "0a4553bd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:47:48.526318Z",
-     "iopub.status.busy": "2026-05-19T21:47:48.526056Z",
-     "iopub.status.idle": "2026-05-19T21:49:07.701043Z",
-     "shell.execute_reply": "2026-05-19T21:49:07.699963Z"
+     "iopub.execute_input": "2026-05-20T16:33:25.990351Z",
+     "iopub.status.busy": "2026-05-20T16:33:25.990134Z",
+     "iopub.status.idle": "2026-05-20T16:34:39.779102Z",
+     "shell.execute_reply": "2026-05-20T16:34:39.777929Z"
     },
     "papermill": {
-     "duration": 79.210401,
-     "end_time": "2026-05-19T21:49:07.701995+00:00",
+     "duration": 73.820392,
+     "end_time": "2026-05-20T16:34:39.780521+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:47:48.491594+00:00",
+     "start_time": "2026-05-20T16:33:25.960129+00:00",
      "status": "completed"
     },
     "tags": []
@@ -5082,14 +5082,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:47:48.534\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:25.997\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:47:49.339\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:26.706\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -5116,14 +5116,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:47:53.174\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:30.278\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:47:54.047\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:31.023\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -5150,14 +5150,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:47:58.083\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:34.575\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:47:58.897\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:35.271\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -5184,14 +5184,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:02.963\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:38.820\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-06 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:03.757\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:39.501\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'antepartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'antepartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -5218,77 +5218,77 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:07.686\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:43.036\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:08.440\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:43.707\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:09.235\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:44.396\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:10.018\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:45.043\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:10.830\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:45.766\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:11.596\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:46.404\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:12.386\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:47.086\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:13.141\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:47.735\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:13.883\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:48.394\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:13.914\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:48.418\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:14.692\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:49.092\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -5315,77 +5315,77 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:18.642\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:53.778\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:19.341\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:54.457\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:20.062\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:55.145\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:20.729\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:55.790\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:21.479\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:56.527\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:22.137\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:57.171\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:22.826\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:57.868\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:23.486\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:58.521\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:24.172\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:59.176\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:24.196\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:59.214\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:24.923\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:33:59.900\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -5412,77 +5412,77 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:28.672\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:03.518\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:29.395\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:04.196\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:30.111\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:04.901\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:30.821\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:05.547\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:31.586\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:06.267\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:32.259\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:06.905\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:32.981\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:07.588\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:33.655\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:08.229\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:34.385\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:08.880\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:34.413\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:08.905\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:35.165\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:09.578\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -5509,77 +5509,77 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:39.017\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:13.142\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-07 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:39.773\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:13.820\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-08 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:40.548\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:14.512\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-09 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:41.293\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:15.160\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-10 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:42.099\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:15.888\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-11 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:42.789\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:16.528\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-12 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:43.532\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:17.222\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-13 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:44.240\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:17.871\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-14 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:44.920\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:18.525\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_obstructed_labor_and_uterine_rupture.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:44.948\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:18.552\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-15 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:45.657\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:19.228\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'postpartum_hemorrhage.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'postpartum_hemorrhage.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -5606,14 +5606,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:49.491\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-16 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:22.841\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-16 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:50.261\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:23.522\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_1\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -5640,14 +5640,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:54.028\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-16 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:27.057\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-16 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:54.751\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:27.732\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_2\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -5674,14 +5674,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:58.438\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-16 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:31.299\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-16 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:48:59.143\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:31.975\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_3\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -5708,14 +5708,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:49:02.854\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-16 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:35.555\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-16 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:49:03.551\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf'.\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:36.229\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36msimulation_4\u001b[0m-\u001b[36mpopulation_manager\u001b[0m:\u001b[36m747\u001b[0m - \u001b[33m\u001b[1mThe 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf' attribute pipeline returned a pd.Series with a different name 'value'. For the column being added to the population state table, we will use 'maternal_sepsis_and_other_maternal_infections.incidence_risk.paf'.\u001b[0m\n"
      ]
     },
     {
@@ -5810,13 +5810,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b30142a3",
+   "id": "e8aab2b4",
    "metadata": {
     "papermill": {
-     "duration": 0.056034,
-     "end_time": "2026-05-19T21:49:07.821857+00:00",
+     "duration": 0.055271,
+     "end_time": "2026-05-20T16:34:39.894031+00:00",
      "exception": false,
-     "start_time": "2026-05-19T21:49:07.765823+00:00",
+     "start_time": "2026-05-20T16:34:39.838760+00:00",
      "status": "completed"
     },
     "tags": []
@@ -5828,20 +5828,18 @@
   {
    "cell_type": "code",
    "execution_count": 49,
-   "id": "e1df0479",
+   "id": "88d26d4d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T21:49:07.942405Z",
-     "iopub.status.busy": "2026-05-19T21:49:07.942137Z",
-     "iopub.status.idle": "2026-05-19T21:51:12.168663Z",
-     "shell.execute_reply": "2026-05-19T21:51:12.167455Z"
+     "iopub.execute_input": "2026-05-20T16:34:40.010146Z",
+     "iopub.status.busy": "2026-05-20T16:34:40.009873Z"
     },
     "papermill": {
-     "duration": 124.352973,
-     "end_time": "2026-05-19T21:51:12.233213+00:00",
+     "duration": null,
+     "end_time": null,
      "exception": false,
-     "start_time": "2026-05-19T21:49:07.880240+00:00",
-     "status": "completed"
+     "start_time": "2026-05-20T16:34:39.953939+00:00",
+     "status": "running"
     },
     "tags": []
    },
@@ -5850,119 +5848,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:49:08.699\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-17 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:40.637\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-17 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:49:09.435\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-18 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:41.269\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-18 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:49:10.174\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-19 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:41.914\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-19 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:49:14.876\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-20 00:00:00\u001b[0m\n"
+      "\u001b[32m2026-05-20 09:34:46.506\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_1\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-20 00:00:00\u001b[0m\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-05-19 14:49:38.265\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-17 00:00:00\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m2026-05-19 14:49:39.027\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-18 00:00:00\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m2026-05-19 14:49:39.743\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-19 00:00:00\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m2026-05-19 14:49:44.428\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-20 00:00:00\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m2026-05-19 14:50:08.713\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-17 00:00:00\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m2026-05-19 14:50:09.475\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-18 00:00:00\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m2026-05-19 14:50:10.248\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-19 00:00:00\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m2026-05-19 14:50:15.208\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_3\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-20 00:00:00\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m2026-05-19 14:50:40.992\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-17 00:00:00\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m2026-05-19 14:50:41.774\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-18 00:00:00\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m2026-05-19 14:50:42.544\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-19 00:00:00\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m2026-05-19 14:50:47.620\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_4\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-20 00:00:00\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "All final YLD checks passed.\n"
+      "\u001b[32m2026-05-20 09:35:08.658\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36msimulation_2\u001b[0m - \u001b[36mvivarium.framework.engine\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1m2025-01-17 00:00:00\u001b[0m\n"
      ]
     }
    ],
@@ -6020,96 +5934,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
-   "id": "f1668342",
+   "execution_count": null,
+   "id": "6027cd76",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-19T21:51:12.359681Z",
-     "iopub.status.busy": "2026-05-19T21:51:12.359002Z",
-     "iopub.status.idle": "2026-05-19T21:51:12.640400Z",
-     "shell.execute_reply": "2026-05-19T21:51:12.639299Z"
-    },
     "papermill": {
-     "duration": 0.345822,
-     "end_time": "2026-05-19T21:51:12.641639+00:00",
-     "exception": false,
-     "start_time": "2026-05-19T21:51:12.295817+00:00",
-     "status": "completed"
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "anemia_status\n",
-       "mild           5381.886283\n",
-       "moderate       5699.991175\n",
-       "not_anemic    27177.965095\n",
-       "severe          888.383433\n",
-       "Name: value, dtype: float64"
-      ]
-     },
-     "execution_count": 50,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "sim.get_results()['anemia_person_time'].groupby('anemia_status').value.sum()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
-   "id": "85947e9f",
+   "execution_count": null,
+   "id": "321732f5",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-19T21:51:12.772985Z",
-     "iopub.status.busy": "2026-05-19T21:51:12.772509Z",
-     "iopub.status.idle": "2026-05-19T21:51:12.785591Z",
-     "shell.execute_reply": "2026-05-19T21:51:12.784364Z"
-    },
     "papermill": {
-     "duration": 0.07834,
-     "end_time": "2026-05-19T21:51:12.786360+00:00",
-     "exception": false,
-     "start_time": "2026-05-19T21:51:12.708020+00:00",
-     "status": "completed"
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "hemoglobin.exposure\n",
-       "mild           946.710472\n",
-       "moderate      1030.997947\n",
-       "not_anemic    4727.227926\n",
-       "severe         181.453799\n",
-       "dtype: float64"
-      ]
-     },
-     "execution_count": 51,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "pd.Series(6 * 7 * (1 / 365.25), index=anemia_status[parent_survived_birth].index).groupby(anemia_status[parent_survived_birth]).sum().sort_index()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "17a42a7d",
+   "id": "8d66e320",
    "metadata": {
     "papermill": {
-     "duration": 0.063865,
-     "end_time": "2026-05-19T21:51:12.917801+00:00",
-     "exception": false,
-     "start_time": "2026-05-19T21:51:12.853936+00:00",
-     "status": "completed"
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
     },
     "tags": []
    },
@@ -6124,111 +5994,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
-   "id": "66e0725a",
+   "execution_count": null,
+   "id": "e8ebc9e7",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-19T21:51:13.036988Z",
-     "iopub.status.busy": "2026-05-19T21:51:13.036717Z",
-     "iopub.status.idle": "2026-05-19T21:51:13.107463Z",
-     "shell.execute_reply": "2026-05-19T21:51:13.106321Z"
-    },
     "papermill": {
-     "duration": 0.132861,
-     "end_time": "2026-05-19T21:51:13.108164+00:00",
-     "exception": false,
-     "start_time": "2026-05-19T21:51:12.975303+00:00",
-     "status": "completed"
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>count</th>\n",
-       "      <th>mean</th>\n",
-       "      <th>std</th>\n",
-       "      <th>min</th>\n",
-       "      <th>25%</th>\n",
-       "      <th>50%</th>\n",
-       "      <th>75%</th>\n",
-       "      <th>max</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>oral_iron_intervention_baseline</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>ifa</th>\n",
-       "      <td>22566.0</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>no_treatment</th>\n",
-       "      <td>37434.0</td>\n",
-       "      <td>3.751138</td>\n",
-       "      <td>4.811385</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>9.922281</td>\n",
-       "      <td>9.922281</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                   count      mean       std  min  25%  50%  \\\n",
-       "oral_iron_intervention_baseline                                               \n",
-       "ifa                              22566.0  0.000000  0.000000  0.0  0.0  0.0   \n",
-       "no_treatment                     37434.0  3.751138  4.811385  0.0  0.0  0.0   \n",
-       "\n",
-       "                                      75%       max  \n",
-       "oral_iron_intervention_baseline                      \n",
-       "ifa                              0.000000  0.000000  \n",
-       "no_treatment                     9.922281  9.922281  "
-      ]
-     },
-     "execution_count": 52,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "compare_population = final_pops['mms_total_scaleup'].join(\n",
     "    final_pops['baseline'],\n",
@@ -6288,21 +6066,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
-   "id": "5e2495c1",
+   "execution_count": null,
+   "id": "d3c45b44",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-19T21:51:13.222760Z",
-     "iopub.status.busy": "2026-05-19T21:51:13.222404Z",
-     "iopub.status.idle": "2026-05-19T21:51:13.258282Z",
-     "shell.execute_reply": "2026-05-19T21:51:13.257484Z"
-    },
     "papermill": {
-     "duration": 0.092822,
-     "end_time": "2026-05-19T21:51:13.259223+00:00",
-     "exception": false,
-     "start_time": "2026-05-19T21:51:13.166401+00:00",
-     "status": "completed"
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
     },
     "tags": []
    },
@@ -6324,14 +6096,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "989621e3",
+   "id": "e52a9879",
    "metadata": {
     "papermill": {
-     "duration": 0.057497,
-     "end_time": "2026-05-19T21:51:13.376585+00:00",
-     "exception": false,
-     "start_time": "2026-05-19T21:51:13.319088+00:00",
-     "status": "completed"
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
     },
     "tags": []
    },
@@ -6359,14 +6131,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 660.578488,
-   "end_time": "2026-05-19T21:51:14.657214+00:00",
+   "duration": null,
+   "end_time": null,
    "environment_variables": {},
    "exception": null,
    "input_path": "/mnt/share/homes/hjafari/repos/vivarium_gates_mncnh/tests/model_notebooks/interactive/interactive_simulation_hemoglobin.ipynb",
    "output_path": "/mnt/share/homes/hjafari/repos/vivarium_gates_mncnh/tests/model_notebooks/interactive/executed/interactive_simulation_hemoglobin.ipynb",
    "parameters": {},
-   "start_time": "2026-05-19T21:40:14.078726+00:00",
+   "start_time": "2026-05-20T16:26:17.789611+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## PPH/APH observers

### Description
- *Category*: observers
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-7078

### Changes and notes
- Add the 6-week to 9-month postpartum period as a new anemia YLD observation interval
- Use non-pregnancy anemia thresholds (80/110/120 g/L) during postpartum for both disability weight calculation and output stratification labels, reflecting that simulants are no longer pregnant
- Add a "timestep" stratification to the anemia YLDs observer so results are disaggregated by simulation event
- Make the anemia_status stratification mapper timestep-aware so output labels always reflect the thresholds actually used in the DW calculation

### Verification and Testing
Ran non-results tests.

<--
*** REMINDER ***
CI WILL NOT RUN ANY TESTS.
MANUALLY RUN TESTS WITH EACH PR.
MAKE SURE CONSTANTS/PATHS.PY IS USING THE CORRECT MODEL RESULTS DIRECTORY.
-->
- [ ] model results directory is up to date
- [X] all tests pass (`pytest --runslow` with both *vivarium_gates_mncnh_artifact* and *vivarium_gates_mncnh_simulation*)

### Next steps

- [X] Merge this pull request
