### PR TITLE
pin vbu<=3.3.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,8 +158,11 @@ build-env: # Create a new environment with installed packages
 	fi
 
 	conda create $(CONDA_CREATE_FLAG) python=$(py) --yes
-# 	Bootstrap vivarium_build_utils into the new environment
-	conda run $(CONDA_RUN_FLAG) pip install vivarium_build_utils
+# 	Bootstrap vivarium_build_utils into the new environment.
+# 	Pin to <=3.3.2 until this model repo's deps are migrated to the post-monorepo names
+# 	NOTE: v3.3.3 / v3.3.4 are post-archive sunset releases of the standalone vbu repo that
+#		were never tagged in the monorepo, so the Jenkins shared library loader can't find them
+	conda run -n $(name) pip install "vivarium_build_utils<=3.3.2"
 #	Install packages based on type
 	@if [ "$(type)" = "simulation" ]; then \
 		conda run $(CONDA_RUN_FLAG) make install ENV_REQS=dev; \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,16 @@
 [build-system]
 requires = ["packaging", "setuptools"]
 
+# Minimal [project] block so vivarium_build_utils' base.mk can parse the
+# distribution name from pyproject.toml instead of falling back to
+# ``$(notdir $(CURDIR))`` (which is unsafe under Jenkins's parallel
+# workspaces — directories like ``<repo>@2`` contain ``@``, which uv
+# rejects in ``--config-settings-package`` values). Everything except
+# ``name`` continues to come from setup.py via the dynamic declaration.
+[project]
+name = "vivarium_gates_mncnh"
+dynamic = ["version"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-nauto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,19 @@ requires = ["packaging", "setuptools"]
 # ``name`` continues to come from setup.py via the dynamic declaration.
 [project]
 name = "vivarium_gates_mncnh"
-dynamic = ["version"]
+# Every other PEP 621 field is still set in setup.py; setuptools requires
+# anything outside [project] but set via setup() to be declared dynamic.
+dynamic = [
+    "version",
+    "description",
+    "readme",
+    "license",
+    "authors",
+    "urls",
+    "dependencies",
+    "optional-dependencies",
+    "scripts",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,10 @@ if __name__ == "__main__":
     install_requirements = [
         "vivarium_dependencies<2.0.0",
         "vivarium_dependencies[pandas,numpy,scipy,click,tables,loguru]",
-        "vivarium_build_utils>=3.0.1",
+        # Pin to <=3.3.2 until this model repo's deps are migrated to the post-monorepo names
+        # NOTE: v3.3.3 / v3.3.4 are post-archive sunset releases of the standalone vbu repo that
+        #   were never tagged in the monorepo, so the Jenkins shared library loader can't find them
+        "vivarium_build_utils>=3.0.1,<=3.3.2",
         "gbd_mapping>=5.0.0,<6.0.0",
         "layered_config_tree<5.0.0",
         "vivarium>=4.0.0, <4.1.0",

--- a/setup.py
+++ b/setup.py
@@ -114,8 +114,9 @@ if __name__ == "__main__":
             "tag_regex": r"^(?P<prefix>v)?(?P<version>[^\+]+)(?P<suffix>.*)?$",
         },
         setup_requires=setup_requires,
-        entry_points="""
-            [console_scripts]
-            make_artifacts=vivarium_gates_mncnh.tools.cli:make_artifacts
-        """,
+        entry_points={
+            "console_scripts": [
+                "make_artifacts=vivarium_gates_mncnh.tools.cli:make_artifacts",
+            ],
+        },
     )

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,8 @@ if __name__ == "__main__":
     ]
 
     setup(
-        name=about["__title__"],
+        # name is declared statically in pyproject.toml's [project] block.
+        # Setuptools errors if it's also passed here.
         description=about["__summary__"],
         long_description=long_description,
         license=about["__license__"],


### PR DESCRIPTION
## Pin make build-env vbu install to <3.3.2

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, data artifact, implementation, observers,
                   post-processing, refactor, revert, test, release, other/misc --> other
- *JIRA issue*: [MIC-7261](https://jira.ihme.washington.edu/browse/MIC-7261)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

Some of the dependencies (e.g. vivarium and possibly others) are pinned
to pre-monorepo versions which in turn pin vbu to its pre-monorepo version.
Until we update all pins to pre-monorepo version, just pin vbu down.

Ironically, vbu shouldn't even be getting pinned in the first place since it's
not used directly by the actual code base - it's only used in the makefile.
An alternative - and arguably better - solution here is to remove the vbu pin
from all framework repos!

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

