### PR TITLE
Consistently do not capture output when running commands in conda env

### DIFF
--- a/src/vivarium_gates_mncnh/tools/utilities.py
+++ b/src/vivarium_gates_mncnh/tools/utilities.py
@@ -235,7 +235,7 @@ def run_command(
         print(f"Command: {full_cmd}")
         print("Auto-confirm: y (continuous)")
     else:
-        cmd = ["conda", "run", "-n", conda_env] + cmd
+        cmd = ["conda", "run", "--no-capture-output", "-n", conda_env] + cmd
         print(f"Command: {' '.join(cmd)}")
 
     print(f"{'='*80}\n")


### PR DESCRIPTION
## Consistently do not capture output when running commands in conda env

### Description
- *Category*: bugfix
- *JIRA issue*: None
- *Research reference*: None

### Changes and notes

Noticed this because without it, my Jobmon URL for my psimulate was not being shown in the terminal when using `run_main_sim.py`.

### Verification and Testing

Ran `run_main_sim.py` and it showed the Jobmon URL.

- [x] model results directory is up to date
- [x] all tests pass (`pytest --runslow` with both *vivarium_gates_mncnh_artifact* and *vivarium_gates_mncnh_simulation*)

### Next steps

- [x] Merge this pull request
- [ ] THIS IS A SENSITIVITY ANALYSIS/EXPERIMENT -- DO NOT MERGE!
