### PR TITLE
Fix shared-env tooling bugs found during template port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ build-env: # Create a new environment with installed packages
 
 	conda create $(CONDA_CREATE_FLAG) python=$(py) --yes
 # 	Bootstrap vivarium_build_utils into the new environment.
-	conda run -n $(name) pip install "vivarium_build_utils>=4.0.0,<5.0.0"
+	conda run $(CONDA_RUN_FLAG) pip install "vivarium_build_utils>=4.0.0,<5.0.0"
 #	Install packages based on type
 	@if [ "$(type)" = "simulation" ]; then \
 		conda run $(CONDA_RUN_FLAG) make install ENV_REQS=dev; \

--- a/README.rst
+++ b/README.rst
@@ -56,15 +56,13 @@ Alternatively, users can manually create conda environments as follows::
   :~$ conda create --name=vivarium_gates_mncnh_simulation python=3.11 git git-lfs
   ...conda will download python and base dependencies...
   :~$ conda activate vivarium_gates_mncnh_simulation
-  (vivarium_gates_mncnh_simulation) :~$ pip install -r requirements.txt
   (vivarium_gates_mncnh_simulation) :~$ pip install -e .[dev]
   ...pip will install vivarium and other requirements...
   (vivarium_gates_mncnh_simulation) :~$ conda deactivate
   :~$ conda create --name=vivarium_gates_mncnh_artifact python=3.11 git git-lfs
   ...conda will download python and base dependencies...
   :~$ conda activate vivarium_gates_mncnh_artifact
-  (vivarium_gates_mncnh_artifact) :~$ pip install -r artifact_requirements.txt
-  (vivarium_gates_mncnh_artifact) :~$ pip install -e .[dev]
+  (vivarium_gates_mncnh_artifact) :~$ pip install -e .[data]
   ...pip will install vivarium and other requirements...
 
 Supported Python versions: 3.10, 3.11

--- a/environment.sh
+++ b/environment.sh
@@ -26,7 +26,7 @@ Help()
    echo
    echo "Script to automatically create and validate conda environments."
    echo
-   echo "Syntax: source environment.sh [-h|t|v|s|f|l]"
+   echo "Syntax: source environment.sh [-h|t|s|f|l]"
    echo "options:"
    echo "h     Print this Help."
    echo "t     Type of conda environment. Either 'simulation' (default) or 'artifact'."
@@ -74,7 +74,6 @@ fi
 # But also clear the trap when exiting to avoid affecting the parent shell
 trap 'trap - ERR && return' ERR
 set -E
-set set -o pipefail
 
 if [[ "$use_shared" == "yes" ]]; then
   # Deactivate any active conda environments so only the venv is active

--- a/src/vivarium_gates_mncnh/tools/utilities.py
+++ b/src/vivarium_gates_mncnh/tools/utilities.py
@@ -182,7 +182,7 @@ def check_conda_environments() -> None:
         if missing_envs:
             raise RuntimeError(
                 f"Missing required conda environments: {', '.join(missing_envs)}\n"
-                f"Please install them by running bash environment.sh before running this script."
+                f"Please install them by running 'source environment.sh' before running this script."
             )
 
         print("All required conda environments found.\n")


### PR DESCRIPTION
## Title: Fix shared-env tooling bugs found during template port

### Description
- *Category*: bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-7303
- *Research reference*: n/a (environment tooling only)

### Changes and notes

Upstreams the fixes made while porting this repo's shared-environment tooling (#294/#301/#330) into the research template ([vivarium_research_template#124](https://github.com/ihmeuw/vivarium_research_template/pull/124)). After this PR, `Makefile` and `environment.sh` are byte-identical to the reviewed template copies.

1. **`Makefile`** — bootstrap `vivarium_build_utils` with `conda run $(CONDA_RUN_FLAG)` instead of `conda run -n $(name)` (regressed in #330). With `build-env path=...`, the env is created at the path but the old line tried to install vbu into an env by *name*, which may not exist. The Jenkins shared-env nightly (`Jenkinsfile.shared-env` in build-utils) invokes `make build-env type=... name=... path=...`, so this is exactly its code path.
2. **`environment.sh`** — delete the `set set -o pipefail` line. The doubled `set` makes it a no-op (it just clobbers positional parameters), so pipefail has never been enabled. Deliberately *not* "fixing" it to `set -o pipefail`: with pipefail real, `env_info=$(conda info --envs | grep $env_name | head -n 1)` fails whenever the env doesn't exist yet (grep exits 1), firing the ERR trap and silently returning before `make build-env` runs — i.e. first-time `source environment.sh` on a fresh clone would abort with no message. It would also leak pipefail into the user's interactive shell permanently (the script is sourced and never restores shell options). Both failure modes were reproduced in bash during review of the template port.
3. **`environment.sh`** — help syntax line said `[-h|t|v|s|f|l]`; there is no `-v` option (getopts is `:hsflt:`).
4. **`environment.sh`** — add missing trailing newline.
5. **`README.rst`** — the manual-install block still said `pip install -r requirements.txt` / `pip install -r artifact_requirements.txt`; those files were deleted by #294. Removed those lines, and the artifact env's editable install now uses `.[data]` (matching what `make build-env type=artifact` installs via `ENV_REQS=data`) instead of `.[dev]`.
6. **`tools/utilities.py`** — the missing-envs error message told users to run `bash environment.sh`, which the script itself now rejects (it must be sourced). Now says `source environment.sh`.

### Verification and Testing

- `bash -n environment.sh` passes; `make -n build-env` and `make -n build-shared-env` dry-run correctly.
- `diff` confirms `Makefile`/`environment.sh` are byte-identical to the template copies that went through multi-agent adversarial review in vivarium_research_template#124 (the pipefail failure modes in item 2 were reproduced there with 3/3 verifier confirmation).
- Repo-wide grep sweep for other references to `pipefail`, the deleted requirements files, the `-v` flag, and `conda run -n`: only benign hits (the notebook-test kernel registration uses its own `conda run -n` against named envs; `environment_lock_pip.txt` in facility_choice is a different, still-existing file).
- Checked `update_readme.yml`/`update_readme.py`: its regexes only touch `python=X.Y` and the "Supported Python versions" line, so the README edit won't be clobbered.
- `setup.py` extras confirmed: `data` = inputs + cluster + lint + test + validation; `dev` = test + cluster + lint + interactive — matching the README's `.[data]`/`.[dev]` guidance.
- Not run here: a live `make build-env` / cluster env build, and the test suites below.

- [ ] model results directory is up to date (n/a — no model code changes)
- [ ] all tests pass (`pytest --runslow` with both *vivarium_gates_mncnh_artifact* and *vivarium_gates_mncnh_simulation*)

### Next steps

- [ ] Merge this pull request
- [ ] THIS IS A SENSITIVITY ANALYSIS/EXPERIMENT -- DO NOT MERGE!

🤖 Generated with [Claude Code](https://claude.com/claude-code)