### PR TITLE
Separate LBWSG-affected causes in neonatal mortality risk

### DIFF
--- a/src/vivarium_gates_mncnh/components/__init__.py
+++ b/src/vivarium_gates_mncnh/components/__init__.py
@@ -16,10 +16,12 @@ from vivarium_gates_mncnh.components.intervention import (
 )
 from vivarium_gates_mncnh.components.intrapartum import ACSAccess, InterventionAccess
 from vivarium_gates_mncnh.components.lbwsg import (
+    BaselineLBWSGRelativeRiskProducer,
     LBWSGMortality,
     LBWSGPAFCalculationExposure,
     LBWSGPAFObserver,
     LBWSGPAFRiskEffect,
+    LBWSGRelativeRiskProducer,
     LBWSGRisk,
     LBWSGRiskEffect,
     PretermPrevalenceObserver,

--- a/src/vivarium_gates_mncnh/components/lbwsg.py
+++ b/src/vivarium_gates_mncnh/components/lbwsg.py
@@ -205,6 +205,11 @@ class LBWSGRisk(LBWSGRisk_):
 
     AXES = [BIRTH_WEIGHT, GESTATIONAL_AGE]
 
+    @staticmethod
+    def get_unmodified_exposure_name(axis: str) -> str:
+        """Return the pre-intervention (unmodified) exposure column name for an axis."""
+        return f"{axis}.unmodified_exposure"
+
     def __init__(self):
         super().__init__()
         self.continuous_propensity_column_name = {
@@ -226,6 +231,13 @@ class LBWSGRisk(LBWSGRisk_):
             initializer=self._initialize_continuous_propensities,
             columns=[self.continuous_propensity_column_name[axis] for axis in self.AXES],
             required_resources=[self.randomness],
+        )
+
+        # Pre-intervention (unmodified) exposure columns. Assigned at ultrasound alongside
+        # the modified ``*.exposure`` columns; initialized to NaN here.
+        builder.population.register_initializer(
+            initializer=self.initialize_unmodified_exposure,
+            columns=[self.get_unmodified_exposure_name(axis) for axis in self.AXES],
         )
 
     #################
@@ -255,6 +267,18 @@ class LBWSGRisk(LBWSGRisk_):
         exposures = pd.DataFrame(
             {
                 self.get_exposure_name(axis): pd.Series(np.nan, index=pop_data.index)
+                for axis in self.AXES
+            }
+        )
+        self.population_view.initialize(exposures)
+
+    def initialize_unmodified_exposure(self, pop_data: SimulantData) -> None:
+        """Initialize unmodified exposure columns to NaN; assigned at ultrasound."""
+        exposures = pd.DataFrame(
+            {
+                self.get_unmodified_exposure_name(axis): pd.Series(
+                    np.nan, index=pop_data.index
+                )
                 for axis in self.AXES
             }
         )
@@ -334,32 +358,85 @@ class LBWSGRisk(LBWSGRisk_):
 
         self.population_view.update(exposure_columns, _update_exposures)
 
+        # Pre-intervention (unmodified) exposure. We call the birth-exposure pipeline
+        # SOURCE (``get_birth_exposure``) directly rather than the pipeline itself so the
+        # intervention modifiers registered on ``{axis}.birth_exposure`` (IFA/MMS additive
+        # effects, oral/IV iron effects) are excluded. The LBWSG birth-exposure
+        # post-processor is a no-op (continuous risk, no category thresholds configured),
+        # so the raw source output equals the final unmodified exposure.
+        unmodified_columns = [self.get_unmodified_exposure_name(axis) for axis in self.AXES]
+
+        def _update_unmodified_exposures(pop: pd.DataFrame) -> pd.DataFrame:
+            raw_exposures = self.get_birth_exposure(event.index)
+            col_mapping = {
+                axis: self.get_unmodified_exposure_name(axis) for axis in self.AXES
+            }
+            return raw_exposures.rename(columns=col_mapping)
+
+        self.population_view.update(unmodified_columns, _update_unmodified_exposures)
+
 
 class LBWSGRiskEffect(LBWSGRiskEffect_):
     """Subclass of LBWSGRiskEffect to be compatible with the wide state table, meaning it
     will query on child lookup columns. This also exposes the PAF as a pipeline so it is
     accessible by the neonatal causes component. The ACMR PAF will be used to calculate a
-    normalizing constant to modify CSMR pipelines for neonatal causes."""
+    normalizing constant to modify CSMR pipelines for neonatal causes.
+
+    This base class applies the LBWSG relative risk in the standard, uniform way (the risk
+    effect's target modifier multiplies RR onto the whole target pipeline). It is used for
+    the cause-specific mortality-risk (CSMR) targets. The all-cause target, which needs the
+    non-uniform affected/unaffected decomposition, is split across two RR *producers*:
+    ``LBWSGRelativeRiskProducer`` (scenario RR + all-cause PAF) and
+    ``BaselineLBWSGRelativeRiskProducer`` (baseline RR).
+
+    The exposure columns this effect reads and the RR column/pipeline names it writes are
+    all resolved through overridable properties, so a subclass can retarget the whole RR
+    track at a different exposure by overriding only the two exposure-column properties and
+    ``get_relative_risk_column_name``."""
+
+    @property
+    def birth_weight_exposure_column_name(self) -> str:
+        return LBWSGRisk_.get_exposure_name(BIRTH_WEIGHT)
+
+    @property
+    def gestational_age_exposure_column_name(self) -> str:
+        return LBWSGRisk_.get_exposure_name(GESTATIONAL_AGE)
 
     @property
     def lbwsg_exposure_column_names(self) -> list[str]:
         return [
-            LBWSGRisk_.get_exposure_name(axis) for axis in [BIRTH_WEIGHT, GESTATIONAL_AGE]
+            self.birth_weight_exposure_column_name,
+            self.gestational_age_exposure_column_name,
         ]
 
     def setup(self, builder: Builder) -> None:
         self._sim_step_name = builder.time.simulation_event_name()
         self.paf_pipeline_name = f"lbwsg_paf_on_{self.target.name}.{self.target.measure}.paf"
-        # age_intervals must be set before super().setup() since it's used by
-        # register_relative_risk_pipeline and initialize_relative_risk
+        # age_intervals must be set before RiskEffect.setup, which registers the RR pipeline
+        # over rr_column_names.
         self.age_intervals = self.get_age_intervals(builder)
-        super().setup(builder)
-        # VPH 5.1 no longer builds ``self.paf_table`` on RiskEffect; build it here
-        # from the PAF data the base now loads onto ``self.paf_data``.
+        # RiskEffect.setup rather than vph's LBWSGRiskEffect.setup: vph declares the RR
+        # initializer against the exposure pipeline and "sex" (the mother's column), but
+        # initialize_relative_risk reads the state-table columns named by
+        # lbwsg_exposure_column_names plus sex_of_child. Declaring what we actually read is
+        # what lets a subclass retarget the whole RR track by overriding the exposure-name
+        # properties.
+        RiskEffect.setup(self, builder)
+        self.interpolator = self.get_interpolator(builder)
+        builder.population.register_initializer(
+            initializer=self.initialize_relative_risk,
+            columns=self.rr_column_names,
+            required_resources=self.lbwsg_exposure_column_names + [COLUMNS.SEX_OF_CHILD],
+        )
+        self.register_paf_pipeline(builder)
+
+    def register_paf_pipeline(self, builder: Builder) -> None:
+        """Expose this target's LBWSG PAF as a pipeline for other components to read."""
+        # VPH 5.1 no longer builds ``self.paf_table`` on RiskEffect; build it here from the
+        # PAF data the base loads onto ``self.paf_data``.
         self.paf_table = self.build_lookup_table(
             builder, "population_attributable_fraction", data_source=self.paf_data
         )
-        # Register a separate PAF pipeline that exposes the PAF for other components
         builder.value.register_attribute_producer(
             self.paf_pipeline_name,
             source=self.paf_table,
@@ -436,6 +513,12 @@ class LBWSGRiskEffect(LBWSGRiskEffect_):
         return interpolators
 
     def _get_relative_risk(self, index: pd.Index) -> pd.Series:
+        """Collapse the per-age-group RR columns into a single age-resolved RR series.
+
+        Identical to the vph base except that it queries the child age column. For each
+        simulant, select the RR column matching its current age group; RR is 1.0 outside
+        the exposed age groups.
+        """
         pop = self.population_view.get(index, self.rr_column_names + [COLUMNS.CHILD_AGE])
         relative_risk = pd.Series(1.0, index=index, name=self.relative_risk_name)
 
@@ -457,8 +540,8 @@ class LBWSGRiskEffect(LBWSGRiskEffect_):
             pop_data.index,
             [COLUMNS.SEX_OF_CHILD] + self.lbwsg_exposure_column_names,
         )
-        birth_weight = pop[LBWSGRisk_.get_exposure_name(BIRTH_WEIGHT)]
-        gestational_age = pop[LBWSGRisk_.get_exposure_name(GESTATIONAL_AGE)]
+        birth_weight = pop[self.birth_weight_exposure_column_name]
+        gestational_age = pop[self.gestational_age_exposure_column_name]
 
         is_male = pop[COLUMNS.SEX_OF_CHILD] == "Male"
         is_tmrel = (self.TMREL_GESTATIONAL_AGE_INTERVAL.left <= gestational_age) & (
@@ -490,6 +573,7 @@ class LBWSGRiskEffect(LBWSGRiskEffect_):
         self.population_view.initialize(pd.concat(relative_risk_columns, axis=1))
 
     def on_time_step(self, event: Event) -> None:
+        """Recompute the RR columns once the ultrasound step has set the exposures."""
         if self._sim_step_name() != SIMULATION_EVENT_NAMES.ULTRASOUND:
             return
 
@@ -497,8 +581,8 @@ class LBWSGRiskEffect(LBWSGRiskEffect_):
             event.index,
             [COLUMNS.SEX_OF_CHILD] + self.lbwsg_exposure_column_names,
         )
-        birth_weight = pop[LBWSGRisk_.get_exposure_name(BIRTH_WEIGHT)]
-        gestational_age = pop[LBWSGRisk_.get_exposure_name(GESTATIONAL_AGE)]
+        birth_weight = pop[self.birth_weight_exposure_column_name]
+        gestational_age = pop[self.gestational_age_exposure_column_name]
 
         is_male = pop[COLUMNS.SEX_OF_CHILD] == "Male"
         is_tmrel = (self.TMREL_GESTATIONAL_AGE_INTERVAL.left <= gestational_age) & (
@@ -535,6 +619,81 @@ class LBWSGRiskEffect(LBWSGRiskEffect_):
         self.population_view.update(rr_columns, _update_rr)
 
 
+class LBWSGRelativeRiskProducer(LBWSGRiskEffect):
+    """Scenario (intervention-modified) all-cause LBWSG relative-risk producer.
+
+    A pure RR *producer*: ``NeonatalMortality.get_acmr_pipeline`` applies the RR
+    non-uniformly (scenario RR onto the LBWSG-affected fraction of ACMR), so this
+    component registers NO uniform target modifier -- a uniform multiply here would
+    double-count.
+
+    Everything else is inherited from the base ``LBWSGRiskEffect``: it reads the
+    intervention-modified ``*.exposure`` columns, publishes the scenario RR pipeline
+    (``PIPELINES.ACMR_RR``, i.e. ``self.relative_risk_name``), and is the SINGLE owner of
+    the all-cause PAF machinery -- the ``lbwsg_paf_on_all_causes...paf`` pipeline
+    registered in the base setup plus the calibration-constant modifier onto
+    ``PIPELINES.ACMR_PAF``. The parallel BASELINE RR track lives in
+    ``BaselineLBWSGRelativeRiskProducer``.
+    """
+
+    def register_target_modifier(self, builder: Builder) -> None:
+        # Register NO target modifier: the RR is applied non-uniformly in
+        # NeonatalMortality.get_acmr_pipeline, so a uniform multiply here would double-count.
+        return
+
+
+class BaselineLBWSGRelativeRiskProducer(LBWSGRelativeRiskProducer):
+    """Baseline (pre-intervention exposure) all-cause LBWSG relative-risk producer.
+
+    The scenario producer's RR track, retargeted at the unmodified exposure: it overrides
+    only the exposure columns it reads, the RR column names it writes, and the RR pipeline
+    it publishes (``PIPELINES.ACMR_BASELINE_RR``). Everything that computes the RR --
+    ``initialize_relative_risk``, ``on_time_step``, and ``_get_relative_risk`` -- is
+    inherited unchanged and follows those overrides.
+    ``NeonatalMortality.get_acmr_pipeline`` applies this RR to the LBWSG-unaffected
+    fraction of ACMR.
+
+    The all-cause PAF pipeline and its calibration-constant modifier are owned by
+    ``LBWSGRelativeRiskProducer`` alone, so this producer inherits the base setup unchanged
+    and simply no-ops ``register_paf_pipeline`` and ``register_calibration_constant_modifier``.
+
+    Note: this and ``LBWSGRelativeRiskProducer`` share the same ``(causal_factor, target)``
+    pair, so the vph-derived component ``name`` would collide; we override ``name`` to
+    disambiguate. Nothing derives a pipeline or column name from ``self.name``.
+    """
+
+    def __init__(self, target: str) -> None:
+        super().__init__(target)
+        # Publish the baseline RR rather than colliding with the scenario producer's
+        # PIPELINES.ACMR_RR. Read by the inherited register_relative_risk_pipeline.
+        self.relative_risk_name = PIPELINES.ACMR_BASELINE_RR
+
+    @property
+    def name(self) -> str:
+        # Disambiguate from LBWSGRelativeRiskProducer, which shares the same
+        # (causal_factor, target) and thus the same vph-derived component name.
+        return f"baseline_{super().name}"
+
+    @property
+    def birth_weight_exposure_column_name(self) -> str:
+        return LBWSGRisk.get_unmodified_exposure_name(BIRTH_WEIGHT)
+
+    @property
+    def gestational_age_exposure_column_name(self) -> str:
+        return LBWSGRisk.get_unmodified_exposure_name(GESTATIONAL_AGE)
+
+    def get_relative_risk_column_name(self, age_group: str) -> str:
+        return f"baseline_{super().get_relative_risk_column_name(age_group)}"
+
+    def register_paf_pipeline(self, builder: Builder) -> None:
+        # The all-cause PAF pipeline is owned by LBWSGRelativeRiskProducer; don't re-register.
+        return
+
+    def register_calibration_constant_modifier(self, builder: Builder) -> None:
+        # The all-cause PAF calibration modifier is owned by LBWSGRelativeRiskProducer.
+        return
+
+
 ####################################
 # LBWSG PAF Calculation Components #
 ####################################
@@ -549,13 +708,10 @@ class LBWSGPAFRiskEffect(LBWSGRiskEffect):
         # initializer with required_resources=["sex"] which doesn't exist in the PAF sim.
         RiskEffect.setup(self, builder)
         self.interpolator = self.get_interpolator(builder)
-        exposure_columns = [
-            LBWSGRisk_.get_exposure_name(axis) for axis in [BIRTH_WEIGHT, GESTATIONAL_AGE]
-        ]
         builder.population.register_initializer(
             initializer=self.initialize_relative_risk,
             columns=self.rr_column_names,
-            required_resources=exposure_columns + [COLUMNS.SEX_OF_CHILD],
+            required_resources=self.lbwsg_exposure_column_names + [COLUMNS.SEX_OF_CHILD],
         )
         # VPH 5.1 no longer builds ``self.paf_table``; build it from ``self.paf_data``.
         self.paf_table = self.build_lookup_table(
@@ -570,51 +726,11 @@ class LBWSGPAFRiskEffect(LBWSGRiskEffect):
 
     def register_relative_risk_pipeline(self, builder: Builder) -> None:
         """Override to avoid depending on the exposure pipeline."""
-        exposure_columns = [
-            LBWSGRisk_.get_exposure_name(axis) for axis in [BIRTH_WEIGHT, GESTATIONAL_AGE]
-        ]
         builder.value.register_attribute_producer(
             self.relative_risk_name,
             self._relative_risk_source,
-            required_resources=exposure_columns,
+            required_resources=self.lbwsg_exposure_column_names,
         )
-
-    def initialize_relative_risk(self, pop_data: SimulantData) -> None:
-        pop = self.population_view.get(
-            pop_data.index,
-            [COLUMNS.SEX_OF_CHILD] + self.lbwsg_exposure_column_names,
-        )
-        birth_weight = pop[LBWSGRisk_.get_exposure_name(BIRTH_WEIGHT)]
-        gestational_age = pop[LBWSGRisk_.get_exposure_name(GESTATIONAL_AGE)]
-
-        is_male = pop[COLUMNS.SEX_OF_CHILD] == "Male"
-        is_tmrel = (self.TMREL_GESTATIONAL_AGE_INTERVAL.left <= gestational_age) & (
-            self.TMREL_BIRTH_WEIGHT_INTERVAL.left <= birth_weight
-        )
-
-        def get_relative_risk_for_age_group(age_group: str) -> pd.Series:
-            column_name = self.get_relative_risk_column_name(age_group)
-            log_relative_risk = pd.Series(0.0, index=pop_data.index, name=column_name)
-
-            male_interpolator = self.interpolator["Male", age_group]
-            log_relative_risk[is_male & ~is_tmrel] = male_interpolator(
-                gestational_age[is_male & ~is_tmrel],
-                birth_weight[is_male & ~is_tmrel],
-                grid=False,
-            )
-            female_interpolator = self.interpolator["Female", age_group]
-            log_relative_risk[~is_male & ~is_tmrel] = female_interpolator(
-                gestational_age[~is_male & ~is_tmrel],
-                birth_weight[~is_male & ~is_tmrel],
-                grid=False,
-            )
-
-            return np.exp(log_relative_risk)
-
-        relative_risk_columns = [
-            get_relative_risk_for_age_group(age_group) for age_group in self.age_intervals
-        ]
-        self.population_view.initialize(pd.concat(relative_risk_columns, axis=1))
 
     def on_time_step(self, event: Event) -> None:
         pass

--- a/src/vivarium_gates_mncnh/components/mortality.py
+++ b/src/vivarium_gates_mncnh/components/mortality.py
@@ -202,6 +202,7 @@ class NeonatalMortality(Component):
             self.name: {
                 "data_sources": {
                     "all_cause_mortality_risk": self.load_all_causes_mortality_data,
+                    "affected_causes_mortality_risk": self.load_affected_causes_mortality_data,
                     "life_expectancy": self.load_life_expectancy_data,
                 }
             }
@@ -218,6 +219,10 @@ class NeonatalMortality(Component):
 
         self.all_cause_mortality_risk = self.build_lookup_table(
             builder, "all_cause_mortality_risk", value_columns="value"
+        )
+        # Aggregate neonatal mortality risk summed over the LBWSG-affected GBD causes.
+        self.affected_causes_mortality_risk = self.build_lookup_table(
+            builder, "affected_causes_mortality_risk", value_columns="value"
         )
         self.life_expectancy = self.build_lookup_table(
             builder, "life_expectancy", value_columns="value"
@@ -237,14 +242,23 @@ class NeonatalMortality(Component):
         # Register pipelines
         self._register_acmr_paf(builder)
 
-        # RiskAffectedPipeline so LBWSGRiskEffect applies its relative risk via the
-        # multiplication combiner. The (1 - ACMR PAF) normalization stays in
-        # ``get_acmr_pipeline``; ACMR's own ``.calibration_constant`` stays 0.
+        # ACMR is registered as a RiskAffectedPipeline so its ``.calibration_constant``
+        # machinery is available (the LBWSG PAF is injected onto the separate
+        # ``{target}.paf`` pipeline, so the calibration constant stays 0). The LBWSG
+        # relative risk is NOT auto-multiplied onto ACMR here: LBWSGRiskEffect skips its
+        # target modifier for the all-cause target, and ``get_acmr_pipeline`` applies the
+        # scenario RR to the LBWSG-affected fraction and the baseline RR to the unaffected
+        # fraction itself (non-uniform application, so it cannot be a uniform combiner
+        # multiply).
         register_risk_affected_attribute_producer(
             builder,
             PIPELINES.ACMR,
             source=self.get_acmr_pipeline,
-            required_resources=[PIPELINES.ACMR_PAF],
+            required_resources=[
+                PIPELINES.ACMR_PAF,
+                PIPELINES.ACMR_RR,
+                PIPELINES.ACMR_BASELINE_RR,
+            ],
         )
         builder.value.register_attribute_producer(
             PIPELINES.DEATH_IN_AGE_GROUP_PROBABILITY,
@@ -347,6 +361,12 @@ class NeonatalMortality(Component):
         child_acmrisk = acmrisk.rename(columns=CHILD_LOOKUP_COLUMN_MAPPER)
         return child_acmrisk
 
+    def load_affected_causes_mortality_data(self, builder: Builder) -> pd.DataFrame:
+        """Load the aggregate mortality risk for the LBWSG-affected causes."""
+        affected = builder.data.load(POPULATION.AFFECTED_CAUSES_MORTALITY_RISK)
+        child_affected = affected.rename(columns=CHILD_LOOKUP_COLUMN_MAPPER)
+        return child_affected
+
     def load_life_expectancy_data(self, builder: Builder) -> pd.DataFrame:
         """Load life expectancy data."""
         life_expectancy = builder.data.load(POPULATION.TMRLE)
@@ -399,11 +419,36 @@ class NeonatalMortality(Component):
         return cause_of_death
 
     def get_acmr_pipeline(self, index: pd.Index) -> pd.Series:
-        """Calculate the all-cause mortality rate adjusted by the PAF."""
-        # NOTE: This will be modified by the LBWSGRiskEffect
+        """Decomposed all-cause neonatal mortality risk.
+
+        Split ACMR into the LBWSG-affected fraction (an artifact key summed over the
+        LBWSG-affected GBD causes) and the unaffected remainder, then apply the LBWSG
+        relative risk to each with a different exposure:
+
+          affected   * (1 - PAF) * RR(scenario exposure)
+        + unaffected * (1 - PAF) * RR(baseline exposure)
+
+        The affected fraction responds to the post-intervention (scenario) exposure; the
+        unaffected fraction responds only to the pre-intervention (baseline) exposure, so
+        LBWSG-affecting interventions (IFA/MMS, IV iron) move affected mortality but leave
+        the unaffected fraction's LBWSG response unchanged. RR is applied here rather than
+        via the risk-effect target modifier because it must be applied non-uniformly.
+
+        The "affected" fraction spans the 12 GBD LBWSG-affected causes
+        (``LBWSG_AFFECTED_CAUSE_IDS``), a broader set than the 4 explicitly-modeled
+        subcauses (``CAUSES_OF_NEONATAL_MORTALITY``), so the "unaffected" term here is NOT
+        the ``other_causes`` cause-of-death bucket computed in ``determine_cause_of_death``.
+        """
         acmr = self.all_cause_mortality_risk(index)
+        affected = self.affected_causes_mortality_risk(index)
+        # ``affected`` and ``acmr`` are independently-drawn GBD quantities, so in some cells
+        # affected > acmr; clamp the remainder at 0 to avoid negative mortality risk (same
+        # precedent as the negative ``other_causes`` clamp in determine_cause_of_death).
+        unaffected = (acmr - affected).clip(lower=0)
         paf = self.population_view.get(index, PIPELINES.ACMR_PAF)
-        return acmr * (1 - paf)
+        scenario_rr = self.population_view.get(index, PIPELINES.ACMR_RR)
+        baseline_rr = self.population_view.get(index, PIPELINES.ACMR_BASELINE_RR)
+        return affected * (1 - paf) * scenario_rr + unaffected * (1 - paf) * baseline_rr
 
     def _register_acmr_paf(self, builder: Builder) -> None:
         """Register the ACMR PAF pipeline."""

--- a/src/vivarium_gates_mncnh/constants/data_keys.py
+++ b/src/vivarium_gates_mncnh/constants/data_keys.py
@@ -19,6 +19,7 @@ class __Population(NamedTuple):
     SCALING_FACTOR: str = "population.scaling_factor"
     ACMR: str = "cause.all_causes.cause_specific_mortality_rate"
     ALL_CAUSES_MORTALITY_RISK: str = "cause.all_causes.all_cause_mortality_risk"
+    AFFECTED_CAUSES_MORTALITY_RISK: str = "cause.all_causes.affected_causes_mortality_risk"
     BIRTH_RATE: str = "population.birth_rate"
     ALL_CAUSE_ADJUSTED_BIRTH_COUNTS: str = "cause.all_causes.adjusted_birth_counts"
 

--- a/src/vivarium_gates_mncnh/constants/data_values.py
+++ b/src/vivarium_gates_mncnh/constants/data_values.py
@@ -60,6 +60,24 @@ DURATIONS = _Durations()
 
 NUM_DRAWS = 250
 
+# GBD 2021 LBWSG-affected cause_ids (human-readable cause names in the inline comments).
+# Consumed by the loader that builds the affected-causes mortality-risk artifact key,
+# which sums deaths over these cause ids.
+LBWSG_AFFECTED_CAUSE_IDS = [
+    302,  # diarrheal_diseases
+    322,  # lower_respiratory_infections
+    328,  # upper_respiratory_infections
+    329,  # otitis_media
+    332,  # meningitis
+    337,  # encephalitis
+    381,  # neonatal_preterm_birth
+    382,  # neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma
+    383,  # neonatal_sepsis_and_other_neonatal_infections
+    384,  # hemolytic_disease_and_other_neonatal_jaundice
+    385,  # other_neonatal_disorders
+    686,  # sudden_infant_death_syndrome
+]
+
 
 class _SimulationEventNames(NamedTuple):
     # Constants for the simulation events. Used for string comparison in components.
@@ -166,6 +184,12 @@ class __Columns(NamedTuple):
     SEX_OF_CHILD = "sex_of_child"
     BIRTH_WEIGHT_EXPOSURE = "birth_weight.exposure"
     GESTATIONAL_AGE_EXPOSURE = "gestational_age.exposure"
+    # Pre-intervention (unmodified) LBWSG exposure: the raw LBWSG-distribution draw
+    # WITHOUT the intervention modifiers (IFA/MMS, oral/IV iron) that shift the
+    # ``*.birth_exposure`` pipelines. Used to compute the baseline all-cause RR for the
+    # LBWSG-unaffected fraction of neonatal mortality (see NeonatalMortality decomposition).
+    BIRTH_WEIGHT_UNMODIFIED_EXPOSURE = "birth_weight.unmodified_exposure"
+    GESTATIONAL_AGE_UNMODIFIED_EXPOSURE = "gestational_age.unmodified_exposure"
     ANC_ATTENDANCE = "anc_attendance"
     TIME_OF_FIRST_ANC_VISIT = "time_of_first_anc_visit"
     TIME_OF_LATER_ANC_VISIT = "time_of_later_anc_visit"
@@ -261,6 +285,9 @@ class __Pipelines(NamedTuple):
     NEONATAL_SEPSIS_RR = "low_birth_weight_and_short_gestation_on_neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk.relative_risk"
     NEONATAL_ENCEPHALOPATHY_RR = "low_birth_weight_and_short_gestation_on_neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.cause_specific_mortality_risk.relative_risk"
     ACMR_RR = "low_birth_weight_and_short_gestation_on_all_causes.all_cause_mortality_risk.relative_risk"
+    # Baseline (pre-intervention exposure) all-cause LBWSG relative risk. Parallel to
+    # ACMR_RR but computed from the unmodified birth weight / gestational age exposure.
+    ACMR_BASELINE_RR = "low_birth_weight_and_short_gestation_on_all_causes.all_cause_mortality_risk.baseline_relative_risk"
     BIRTH_WEIGHT_EXPOSURE = "birth_weight.birth_exposure"
     GESTATIONAL_AGE_EXPOSURE = "gestational_age.birth_exposure"
 

--- a/src/vivarium_gates_mncnh/data/extra_gbd.py
+++ b/src/vivarium_gates_mncnh/data/extra_gbd.py
@@ -68,7 +68,9 @@ def get_birth_counts(location: str) -> pd.DataFrame:
 
 
 @vi_utils.cache
-def get_mortality_death_counts(location: str, age_group_id: int, gbd_id: int) -> pd.DataFrame:
+def get_mortality_death_counts(
+    location: str, age_group_id: int, gbd_id: int | list[int]
+) -> pd.DataFrame:
     location_id = utility_data.get_location_id(location)
     data = base_data.get_draws(
         release_id=gbd_constants.RELEASE_IDS.GBD_2023,

--- a/src/vivarium_gates_mncnh/data/loader.py
+++ b/src/vivarium_gates_mncnh/data/loader.py
@@ -61,6 +61,7 @@ def get_data(
         data_keys.POPULATION.SCALING_FACTOR: load_scaling_factor,
         data_keys.POPULATION.ACMR: load_standard_data,
         data_keys.POPULATION.ALL_CAUSES_MORTALITY_RISK: load_mortality_risk,
+        data_keys.POPULATION.AFFECTED_CAUSES_MORTALITY_RISK: load_affected_causes_mortality_risk,
         data_keys.POPULATION.BIRTH_RATE: load_birth_rate,
         data_keys.POPULATION.ALL_CAUSE_ADJUSTED_BIRTH_COUNTS: load_adjusted_birth_counts,
         data_keys.PREGNANCY.ASFR: load_asfr,
@@ -1184,6 +1185,40 @@ def load_mortality_risk(
     return mortality_risk
 
 
+def load_affected_causes_mortality_risk(
+    key: str, location: str, years: Optional[Union[int, str, List[int]]] = None
+) -> pd.DataFrame:
+    draw_columns = [f"draw_{i:d}" for i in range(data_values.NUM_DRAWS)]
+
+    # Sum early and late neonatal deaths across all LBWSG-affected causes. get_draws
+    # (via get_mortality_death_counts) accepts the full cause-id list and returns one
+    # row per cause, so a single call per age group replaces the previous per-cause loop
+    # of slow GBD round-trips; summing the draws over the causes within each demographic
+    # cell reproduces what the per-cause loop + add produced.
+    enn_deaths = get_deaths_summed_over_causes(
+        age_group_id=2,
+        location=location,
+        draw_cols=draw_columns,
+        gbd_ids=data_values.LBWSG_AFFECTED_CAUSE_IDS,
+    )
+    lnn_deaths = get_deaths_summed_over_causes(
+        age_group_id=3,
+        location=location,
+        draw_cols=draw_columns,
+        gbd_ids=data_values.LBWSG_AFFECTED_CAUSE_IDS,
+    )
+    deaths = pd.concat([enn_deaths, lnn_deaths])
+
+    beginning_of_age_group_pop = get_data(
+        data_keys.POPULATION.ALL_CAUSE_ADJUSTED_BIRTH_COUNTS,
+        location,
+        years,
+    )
+
+    mortality_risk = deaths / beginning_of_age_group_pop
+    return mortality_risk
+
+
 def load_adjusted_birth_counts(
     key: str, location: str, years: Optional[Union[int, str, List[int]]] = None
 ) -> pd.DataFrame:
@@ -1944,5 +1979,26 @@ def get_deaths(age_group_id: int, location: str, draw_cols: list[str], gbd_id: i
         location=location, age_group_id=age_group_id, gbd_id=gbd_id
     )
     deaths = deaths.set_index(["location_id", "sex_id", "age_group_id", "year_id"])[draw_cols]
+    deaths = reshape_to_vivarium_format(deaths, location)
+    return deaths
+
+
+def get_deaths_summed_over_causes(
+    age_group_id: int, location: str, draw_cols: list[str], gbd_ids: list[int]
+):
+    """Death counts for a single age group summed over multiple GBD causes.
+
+    ``get_mortality_death_counts`` (get_draws) returns one row per cause (a ``cause_id``
+    column) when passed a list of cause ids, so a single call replaces a per-cause loop;
+    grouping on the demographic cell and summing the draws reproduces what summing the
+    per-cause ``get_deaths`` results would have produced (``reshape_to_vivarium_format``
+    is a per-cell relabel, so summing before vs. after reshaping is equivalent).
+    """
+    deaths = extra_gbd.get_mortality_death_counts(
+        location=location, age_group_id=age_group_id, gbd_id=gbd_ids
+    )
+    deaths = deaths.groupby(["location_id", "sex_id", "age_group_id", "year_id"])[
+        draw_cols
+    ].sum()
     deaths = reshape_to_vivarium_format(deaths, location)
     return deaths

--- a/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_mncnh/model_specifications/model_spec.yaml
@@ -21,7 +21,8 @@ components:
             - AbortionMiscarriageEctopicPregnancy()
             - MaternalDisordersBurden()
             - LBWSGRisk()
-            - LBWSGRiskEffect('cause.all_causes.all_cause_mortality_risk')
+            - LBWSGRelativeRiskProducer('cause.all_causes.all_cause_mortality_risk')
+            - BaselineLBWSGRelativeRiskProducer('cause.all_causes.all_cause_mortality_risk')
             - LBWSGRiskEffect('cause.neonatal_sepsis_and_other_neonatal_infections.cause_specific_mortality_risk')
             - LBWSGRiskEffect('cause.neonatal_preterm_birth_with_rds.cause_specific_mortality_risk')
             - LBWSGRiskEffect('cause.neonatal_preterm_birth_without_rds.cause_specific_mortality_risk')
@@ -79,7 +80,7 @@ components:
 configuration:
     input_data:
         input_draw_number: 60
-        artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/model36.2/ethiopia.hdf"
+        artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_mncnh/artifacts/model41.0/ethiopia.hdf"
     interpolation:
         order: 0
         extrapolate: True


### PR DESCRIPTION
### Description
- *Category*: implementation
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-7320
- *Research reference*: https://github.com/ihmeuw/vivarium_research/pull/1760 — [neonatal cause model, ACMRisk LBWSG decomposition](https://vivarium-research.readthedocs.io/en/latest/models/causes/neonatal/index.html#cause-neonatal-disorders-mncnh)

### Changes and notes

Separates the LBWSG **causal** effect from its **non-causal** (confounded) association in the
neonatal all-cause mortality-risk (ACMRisk) calculation, per research PR #1760. Previously the
scenario LBWSG relative risk scaled *all* of ACMRisk, so a birthweight/gestational-age
intervention wrongly moved mortality from causes LBWSG doesn't cause (e.g. congenital anomalies).

Now `ACMRisk = affected·(1−PAF)·RR(scenario exposure) + unaffected·(1−PAF)·RR(baseline exposure)`,
where `affected = Σ CSMRisk` over the 12 GBD-2021 LBWSG-affected causes and
`unaffected = ACMRisk − affected`. Interventions therefore move only the affected fraction.

Layered commits:
1. **Artifact loader** — new key `cause.all_causes.affected_causes_mortality_risk` (sum of neonatal
   deaths over the 12 affected GBD causes / adjusted birth counts).
2. **Component** — the decomposition in `NeonatalMortality.get_acmr_pipeline`; a new pre-intervention
   ("unmodified") LBWSG exposure and a baseline all-cause RR pipeline in `LBWSGRiskEffect`; the
   all-cause target skips its uniform RR modifier so the RR is applied non-uniformly. The
   modeled-subcause subtract/add-back is unchanged.
3. **Review fixes** — clamp `unaffected ≥ 0`; batch the loader's GBD pull (24 calls → 2); DRY the RR
   helpers; docstrings.
4. **Tests** — white-box unit tests for the decomposition arithmetic + a gated InteractiveContext
   check file.

Guidance for reviewers: the interesting file is `components/lbwsg.py` (the baseline-RR pathway and
the `register_target_modifier` skip). No `vivarium`/`vivarium_public_health` changes. Implementation
was checked line-by-line against the merged research docs.

**Note on `other_causes` vs. the algebraic `unaffected` term:** the sim only models 4 of the 12
affected causes; the other 8 (diarrhea, LRI, meningitis, SIDS, …) stay lumped in `other_causes` at
the *scenario* RR, so observable `other_causes` is not identical to the frozen `ACMRisk_unaffected`
and moves slightly under intervention. This matches the spec; see the verification below.

### Verification and Testing

Artifact rebuild is **surgical** for review: the new key was appended to a private copy of
`model33.1/ethiopia.hdf` (existing keys skipped). Against **real GBD**, the loader batched correctly
and `affected ≤ all_cause` held in **0/1000** draw-cells.

- **Unit tests** (`tests/test_neonatal_mortality_decomposition.py`, no artifact needed): **16 pass**
  — exact decomposition arithmetic, the clamp, and the identity-collapse (`scenario RR == baseline RR`
  → old `acmr·(1−PAF)·RR`).
- **Behavioral sim-verify** (baseline vs `mms_total_scaleup`, 100k, common random numbers) — all four
  research expectations hold:

  | | affected rate | other-causes rate |
  |---|---|---|
  | baseline | 0.01758 | 0.01118 |
  | mms_total_scaleup | 0.01618 | 0.01098 |

  - Affected mortality **responds to MMS** (−7.9%); other-causes **~invariant** (−1.8%, the expected
    small residual from the 8 non-modeled affected causes).
  - LBWSG gradient (baseline): affected rate `BW<2500g` 0.0818 vs `BW≥2500g` 0.0061; other-causes
    0.0439 vs 0.0053 — both vary with exposure, only affected responds to intervention.

**Known limitation (follow-up, not a blocker):** the gated checks in
`tests/test_lbwsg_affected_causes.py` build on the pre-existing `tests/utilities.py`
`get_births_and_deaths_idx` helper (also behind the already-`@skip`ped `test_neonatal_acmr` /
`test_neonatal_csmr`), whose neonatal age-window doesn't match the interactive states, so they don't
yet pass against a keyed artifact. Repairing that shared harness + un-skipping the neonatal V&V is a
separate follow-up.

- [ ] model results directory is up to date
- [ ] all tests pass (`pytest --runslow` with both *vivarium_gates_mncnh_artifact* and *vivarium_gates_mncnh_simulation*)

### Next steps

- [ ] Rebuild the production artifact with the new key (`make_artifacts`, all locations) before a run request
- [ ] Follow-up: fix `get_births_and_deaths_idx` and un-skip neonatal V&V so the gated checks run
- [ ] Merge this pull request

🤖 Generated with [Claude Code](https://claude.com/claude-code)
