### PR TITLE
Fix time format in run_main_sim.py

### DIFF
--- a/src/vivarium_gates_mncnh/tools/run_main_sim.py
+++ b/src/vivarium_gates_mncnh/tools/run_main_sim.py
@@ -142,7 +142,7 @@ def run_sim(
                 "-m",
                 "1",
                 "-r",
-                "15:00",
+                "00:15:00",
                 "-o",
                 str(output_path),
                 str(MODEL_SPEC_PATH),


### PR DESCRIPTION
## Fix time format in run_main_sim.py

### Description
- *Category*: bugfix
- *JIRA issue*: None
- *Research reference*: None

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

### Verification and Testing

Before this change I got `Error: Invalid value for '--max-runtime' / '-r': Invalid runtime '15:00'. Expected format hh:mm:ss.`. After making this change I was able to run a sim.

- [ ] model results directory is up to date
- [ ] all tests pass (`pytest --runslow` with both *vivarium_gates_mncnh_artifact* and *vivarium_gates_mncnh_simulation*)

### Next steps

- [x] Merge this pull request
- [ ] THIS IS A SENSITIVITY ANALYSIS/EXPERIMENT -- DO NOT MERGE!
